### PR TITLE
feat: adding tx submission standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maestro-org/typescript-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "TypeScript SDK for the Maestro Dapp Platform",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/api/transactionManager/helpers.ts
+++ b/src/api/transactionManager/helpers.ts
@@ -109,7 +109,7 @@ export const TransactionManagerApiAxiosParamCreator = function (configuration: C
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        txManagerSubmit: async (body: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        txManagerSubmit: async (body: string | Uint8Array, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('txManagerSubmit', 'body', body);
             const localVarPath = `/txmanager`;
@@ -226,7 +226,7 @@ export const TransactionManagerApiFp = function (configuration: Configuration) {
          * @throws {RequiredError}
          */
         async txManagerSubmit(
-            body: string,
+            body: string | Uint8Array,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.txManagerSubmit(body, options);

--- a/src/api/transactionManager/helpers.ts
+++ b/src/api/transactionManager/helpers.ts
@@ -133,8 +133,8 @@ export const TransactionManagerApiAxiosParamCreator = function (configuration: C
                 ...headersFromBaseOptions,
                 ...options.headers,
             };
-            localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration);
-
+            // localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration);
+            localVarRequestOptions.data = typeof body === 'string' ? Buffer.from(body, 'hex') : Buffer.from(body);
             return {
                 url: toPathString(localVarUrlObj),
                 options: localVarRequestOptions,

--- a/src/api/transactionManager/index.ts
+++ b/src/api/transactionManager/index.ts
@@ -46,7 +46,7 @@ export class TransactionManagerApi extends BaseAPI {
      * @throws {RequiredError}
      * @memberof TransactionManagerApi
      */
-    public txManagerSubmit(body: string, options?: AxiosRequestConfig) {
+    public txManagerSubmit(body: string | Uint8Array, options?: AxiosRequestConfig) {
         return TransactionManagerApiFp(this.configuration)
             .txManagerSubmit(body, options)
             .then((request) => request(this.axios));


### PR DESCRIPTION
## Summary

Adding industry standard for code submission. For tx manager submission api, would convert it from string to buffer when the txSubmit. As for the signed tx it would mostly be in form of `hex cbor`

## Type of Change

Please mark the relevant option(s) for your pull request:

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)

## Additional Information

If you have any additional information or context to provide, such as screenshots, relevant issues, or other details, please include them here.

