### PR TITLE
Feature/change query param to accept typed objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maestro-org/typescript-sdk",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "TypeScript SDK for the Maestro Dapp Platform",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maestro-org/typescript-sdk",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "TypeScript SDK for the Maestro Dapp Platform",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/api/accounts/helpers.ts
+++ b/src/api/accounts/helpers.ts
@@ -29,7 +29,7 @@ export const AccountsApiAxiosParamCreator = function (configuration: Configurati
          * Returns a list of addresses seen on-chain which use the specified stake key
          * @summary Stake account addresses
          * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-         * @param {AccountAddressesQueryParams | null} [localVarQueryParameter] Query parameters.
+         * @param {AccountAddressesQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -460,7 +460,7 @@ export const AccountsApiFp = function (configuration: Configuration) {
          * Returns a list of addresses seen on-chain which use the specified stake key
          * @summary Stake account addresses
          * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-         * @param {AccountAddressesQueryParams | null} [queryParams] Query parameters.
+         * @param {AccountAddressesQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */

--- a/src/api/accounts/helpers.ts
+++ b/src/api/accounts/helpers.ts
@@ -17,6 +17,7 @@ import {
     PaginatedAccountReward,
     PaginatedAccountUpdate,
 } from '../type';
+import { AccountAddressesQueryParams } from './type';
 
 /**
  * AccountsApi - axios parameter creator
@@ -28,15 +29,13 @@ export const AccountsApiAxiosParamCreator = function (configuration: Configurati
          * Returns a list of addresses seen on-chain which use the specified stake key
          * @summary Stake account addresses
          * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AccountAddressesQueryParams | null} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         accountAddresses: async (
             stakeAddr: string,
-            count?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter: AccountAddressesQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'stakeAddr' is not null or undefined
@@ -51,18 +50,9 @@ export const AccountsApiAxiosParamCreator = function (configuration: Configurati
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -353,19 +343,17 @@ export const AccountsApiFactory = function (configuration: Configuration, basePa
          * Returns a list of addresses seen on-chain which use the specified stake key
          * @summary Stake account addresses
          * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AccountAddressesQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         accountAddresses(
             stakeAddr: string,
-            count?: number | null,
-            cursor?: string | null,
+            queryParams: AccountAddressesQueryParams,
             options?: any,
         ): AxiosPromise<PaginatedAddress> {
             return localVarFp
-                .accountAddresses(stakeAddr, count, cursor, options)
+                .accountAddresses(stakeAddr, queryParams, options)
                 .then((request) => request(axios, basePath));
         },
         /**
@@ -472,23 +460,16 @@ export const AccountsApiFp = function (configuration: Configuration) {
          * Returns a list of addresses seen on-chain which use the specified stake key
          * @summary Stake account addresses
          * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AccountAddressesQueryParams | null} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async accountAddresses(
             stakeAddr: string,
-            count?: number | null,
-            cursor?: string | null,
+            queryParams?: AccountAddressesQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAddress>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.accountAddresses(
-                stakeAddr,
-                count,
-                cursor,
-                options,
-            );
+            const localVarAxiosArgs = await localVarAxiosParamCreator.accountAddresses(stakeAddr, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**

--- a/src/api/accounts/helpers.ts
+++ b/src/api/accounts/helpers.ts
@@ -22,6 +22,7 @@ import {
     AccountAssetsQueryParams,
     AccountHistoryQueryParams,
     AccountRewardsQueryParams,
+    AccountUpdatesQueryParams,
 } from './type';
 
 /**
@@ -240,15 +241,13 @@ export const AccountsApiAxiosParamCreator = function (configuration: Configurati
          * Returns a list of updates relating to the specified stake key ( `registration`, `deregistration`, `delegation`, `withdrawal`)
          * @summary Stake account updates
          * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AccountUpdatesQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         accountUpdates: async (
             stakeAddr: string,
-            count?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter: AccountUpdatesQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'stakeAddr' is not null or undefined
@@ -263,18 +262,9 @@ export const AccountsApiAxiosParamCreator = function (configuration: Configurati
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -498,18 +488,16 @@ export const AccountsApiFp = function (configuration: Configuration) {
          * Returns a list of updates relating to the specified stake key ( `registration`, `deregistration`, `delegation`, `withdrawal`)
          * @summary Stake account updates
          * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AccountUpdatesQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async accountUpdates(
             stakeAddr: string,
-            count?: number | null,
-            cursor?: string | null,
+            queryParams?: AccountUpdatesQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAccountUpdate>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.accountUpdates(stakeAddr, count, cursor, options);
+            const localVarAxiosArgs = await localVarAxiosParamCreator.accountUpdates(stakeAddr, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
     };

--- a/src/api/accounts/helpers.ts
+++ b/src/api/accounts/helpers.ts
@@ -17,7 +17,12 @@ import {
     PaginatedAccountReward,
     PaginatedAccountUpdate,
 } from '../type';
-import { AccountAddressesQueryParams, AccountAssetsQueryParams, AccountHistoryQueryParams } from './type';
+import {
+    AccountAddressesQueryParams,
+    AccountAssetsQueryParams,
+    AccountHistoryQueryParams,
+    AccountRewardsQueryParams,
+} from './type';
 
 /**
  * AccountsApi - axios parameter creator
@@ -193,15 +198,13 @@ export const AccountsApiAxiosParamCreator = function (configuration: Configurati
          * Returns a list of staking-related rewards for the specified stake key (pool `member` or `leader` rewards, deposit `refund`)
          * @summary Stake account rewards
          * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AccountRewardsQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         accountRewards: async (
             stakeAddr: string,
-            count?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter: AccountRewardsQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'stakeAddr' is not null or undefined
@@ -216,18 +219,9 @@ export const AccountsApiAxiosParamCreator = function (configuration: Configurati
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -488,18 +482,16 @@ export const AccountsApiFp = function (configuration: Configuration) {
          * Returns a list of staking-related rewards for the specified stake key (pool `member` or `leader` rewards, deposit `refund`)
          * @summary Stake account rewards
          * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AccountRewardsQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async accountRewards(
             stakeAddr: string,
-            count?: number | null,
-            cursor?: string | null,
+            queryParams?: AccountRewardsQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAccountReward>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.accountRewards(stakeAddr, count, cursor, options);
+            const localVarAxiosArgs = await localVarAxiosParamCreator.accountRewards(stakeAddr, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**

--- a/src/api/accounts/helpers.ts
+++ b/src/api/accounts/helpers.ts
@@ -17,7 +17,7 @@ import {
     PaginatedAccountReward,
     PaginatedAccountUpdate,
 } from '../type';
-import { AccountAddressesQueryParams, AccountAssetsQueryParams } from './type';
+import { AccountAddressesQueryParams, AccountAssetsQueryParams, AccountHistoryQueryParams } from './type';
 
 /**
  * AccountsApi - axios parameter creator
@@ -113,17 +113,13 @@ export const AccountsApiAxiosParamCreator = function (configuration: Configurati
          * Returns per-epoch history for the specified stake key
          * @summary Stake account history
          * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-         * @param {number | null} [epochNo] Fetch result for only a specific epoch
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AccountHistoryQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         accountHistory: async (
             stakeAddr: string,
-            epochNo?: number | null,
-            count?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter: AccountHistoryQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'stakeAddr' is not null or undefined
@@ -138,22 +134,9 @@ export const AccountsApiAxiosParamCreator = function (configuration: Configurati
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (epochNo !== undefined) {
-                localVarQueryParameter.epoch_no = epochNo;
-            }
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -475,26 +458,16 @@ export const AccountsApiFp = function (configuration: Configuration) {
          * Returns per-epoch history for the specified stake key
          * @summary Stake account history
          * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-         * @param {number | null} [epochNo] Fetch result for only a specific epoch
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AccountHistoryQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async accountHistory(
             stakeAddr: string,
-            epochNo?: number | null,
-            count?: number | null,
-            cursor?: string | null,
+            queryParams?: AccountHistoryQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAccountHistory>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.accountHistory(
-                stakeAddr,
-                epochNo,
-                count,
-                cursor,
-                options,
-            );
+            const localVarAxiosArgs = await localVarAxiosParamCreator.accountHistory(stakeAddr, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**

--- a/src/api/accounts/helpers.ts
+++ b/src/api/accounts/helpers.ts
@@ -17,7 +17,7 @@ import {
     PaginatedAccountReward,
     PaginatedAccountUpdate,
 } from '../type';
-import { AccountAddressesQueryParams } from './type';
+import { AccountAddressesQueryParams, AccountAssetsQueryParams } from './type';
 
 /**
  * AccountsApi - axios parameter creator
@@ -71,17 +71,13 @@ export const AccountsApiAxiosParamCreator = function (configuration: Configurati
          * Returns a list of native assets which are owned by addresses with the specified stake key
          * @summary Stake account assets
          * @param {string} stakeAddr Bech32 encoded reward/stake address (\&#39;stake1...\&#39;)
-         * @param {string | null} [policy] Filter results to only show assets of the specified policy
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AccountAssetsQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         accountAssets: async (
             stakeAddr: string,
-            policy?: string | null,
-            count?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter: AccountAssetsQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'stakeAddr' is not null or undefined
@@ -96,22 +92,9 @@ export const AccountsApiAxiosParamCreator = function (configuration: Configurati
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (policy !== undefined) {
-                localVarQueryParameter.policy = policy;
-            }
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -332,122 +315,122 @@ export const AccountsApiAxiosParamCreator = function (configuration: Configurati
     };
 };
 
-/**
- * AccountsApi - factory interface
- * @export
- */
-export const AccountsApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = AccountsApiFp(configuration);
-    return {
-        /**
-         * Returns a list of addresses seen on-chain which use the specified stake key
-         * @summary Stake account addresses
-         * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-         * @param {AccountAddressesQueryParams} [queryParams] Query parameters.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        accountAddresses(
-            stakeAddr: string,
-            queryParams: AccountAddressesQueryParams,
-            options?: any,
-        ): AxiosPromise<PaginatedAddress> {
-            return localVarFp
-                .accountAddresses(stakeAddr, queryParams, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns a list of native assets which are owned by addresses with the specified stake key
-         * @summary Stake account assets
-         * @param {string} stakeAddr Bech32 encoded reward/stake address (\&#39;stake1...\&#39;)
-         * @param {string | null} [policy] Filter results to only show assets of the specified policy
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        accountAssets(
-            stakeAddr: string,
-            policy?: string | null,
-            count?: number | null,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedAsset> {
-            return localVarFp
-                .accountAssets(stakeAddr, policy, count, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns per-epoch history for the specified stake key
-         * @summary Stake account history
-         * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-         * @param {number | null} [epochNo] Fetch result for only a specific epoch
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        accountHistory(
-            stakeAddr: string,
-            epochNo?: number | null,
-            count?: number | null,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedAccountHistory> {
-            return localVarFp
-                .accountHistory(stakeAddr, epochNo, count, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns various information regarding a stake account
-         * @summary Stake account information
-         * @param {string} stakeAddr Bech32 encoded reward/stake address (\&#39;stake1...\&#39;)
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        accountInfo(stakeAddr: string, options?: any): AxiosPromise<TimestampedAccountInfo> {
-            return localVarFp.accountInfo(stakeAddr, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns a list of staking-related rewards for the specified stake key (pool `member` or `leader` rewards, deposit `refund`)
-         * @summary Stake account rewards
-         * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        accountRewards(
-            stakeAddr: string,
-            count?: number | null,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedAccountReward> {
-            return localVarFp
-                .accountRewards(stakeAddr, count, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns a list of updates relating to the specified stake key ( `registration`, `deregistration`, `delegation`, `withdrawal`)
-         * @summary Stake account updates
-         * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        accountUpdates(
-            stakeAddr: string,
-            count?: number | null,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedAccountUpdate> {
-            return localVarFp
-                .accountUpdates(stakeAddr, count, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-    };
-};
+// /**
+//  * AccountsApi - factory interface
+//  * @export
+//  */
+// export const AccountsApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
+//     const localVarFp = AccountsApiFp(configuration);
+//     return {
+//         /**
+//          * Returns a list of addresses seen on-chain which use the specified stake key
+//          * @summary Stake account addresses
+//          * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
+//          * @param {AccountAddressesQueryParams} [queryParams] Query parameters.
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         accountAddresses(
+//             stakeAddr: string,
+//             queryParams: AccountAddressesQueryParams,
+//             options?: any,
+//         ): AxiosPromise<PaginatedAddress> {
+//             return localVarFp
+//                 .accountAddresses(stakeAddr, queryParams, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns a list of native assets which are owned by addresses with the specified stake key
+//          * @summary Stake account assets
+//          * @param {string} stakeAddr Bech32 encoded reward/stake address (\&#39;stake1...\&#39;)
+//          * @param {string | null} [policy] Filter results to only show assets of the specified policy
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         accountAssets(
+//             stakeAddr: string,
+//             policy?: string | null,
+//             count?: number | null,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedAsset> {
+//             return localVarFp
+//                 .accountAssets(stakeAddr, policy, count, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns per-epoch history for the specified stake key
+//          * @summary Stake account history
+//          * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
+//          * @param {number | null} [epochNo] Fetch result for only a specific epoch
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         accountHistory(
+//             stakeAddr: string,
+//             epochNo?: number | null,
+//             count?: number | null,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedAccountHistory> {
+//             return localVarFp
+//                 .accountHistory(stakeAddr, epochNo, count, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns various information regarding a stake account
+//          * @summary Stake account information
+//          * @param {string} stakeAddr Bech32 encoded reward/stake address (\&#39;stake1...\&#39;)
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         accountInfo(stakeAddr: string, options?: any): AxiosPromise<TimestampedAccountInfo> {
+//             return localVarFp.accountInfo(stakeAddr, options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns a list of staking-related rewards for the specified stake key (pool `member` or `leader` rewards, deposit `refund`)
+//          * @summary Stake account rewards
+//          * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         accountRewards(
+//             stakeAddr: string,
+//             count?: number | null,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedAccountReward> {
+//             return localVarFp
+//                 .accountRewards(stakeAddr, count, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns a list of updates relating to the specified stake key ( `registration`, `deregistration`, `delegation`, `withdrawal`)
+//          * @summary Stake account updates
+//          * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         accountUpdates(
+//             stakeAddr: string,
+//             count?: number | null,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedAccountUpdate> {
+//             return localVarFp
+//                 .accountUpdates(stakeAddr, count, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//     };
+// };
 
 /**
  * AccountsApi - functional programming interface
@@ -476,26 +459,16 @@ export const AccountsApiFp = function (configuration: Configuration) {
          * Returns a list of native assets which are owned by addresses with the specified stake key
          * @summary Stake account assets
          * @param {string} stakeAddr Bech32 encoded reward/stake address (\&#39;stake1...\&#39;)
-         * @param {string | null} [policy] Filter results to only show assets of the specified policy
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AccountAssetsQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async accountAssets(
             stakeAddr: string,
-            policy?: string | null,
-            count?: number | null,
-            cursor?: string | null,
+            queryParams?: AccountAssetsQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAsset>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.accountAssets(
-                stakeAddr,
-                policy,
-                count,
-                cursor,
-                options,
-            );
+            const localVarAxiosArgs = await localVarAxiosParamCreator.accountAssets(stakeAddr, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**

--- a/src/api/accounts/index.ts
+++ b/src/api/accounts/index.ts
@@ -1,7 +1,12 @@
 import { AxiosRequestConfig } from 'axios';
 import { BaseAPI } from '../../base';
 import { AccountsApiFp } from './helpers';
-import { AccountAddressesQueryParams, AccountAssetsQueryParams, AccountHistoryQueryParams } from './type';
+import {
+    AccountAddressesQueryParams,
+    AccountAssetsQueryParams,
+    AccountHistoryQueryParams,
+    AccountRewardsQueryParams,
+} from './type';
 
 /**
  * AccountsApi - object-oriented interface
@@ -77,20 +82,14 @@ export class AccountsApi extends BaseAPI {
      * Returns a list of staking-related rewards for the specified stake key (pool `member` or `leader` rewards, deposit `refund`)
      * @summary Stake account rewards
      * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-     * @param {number | null} [count] The max number of results per page
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {AccountRewardsQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AccountsApi
      */
-    public accountRewards(
-        stakeAddr: string,
-        count?: number | null,
-        cursor?: string | null,
-        options?: AxiosRequestConfig,
-    ) {
+    public accountRewards(stakeAddr: string, queryParams?: AccountRewardsQueryParams, options?: AxiosRequestConfig) {
         return AccountsApiFp(this.configuration)
-            .accountRewards(stakeAddr, count, cursor, options)
+            .accountRewards(stakeAddr, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/accounts/index.ts
+++ b/src/api/accounts/index.ts
@@ -1,6 +1,7 @@
 import { AxiosRequestConfig } from 'axios';
 import { BaseAPI } from '../../base';
 import { AccountsApiFp } from './helpers';
+import { AccountAddressesQueryParams } from './type';
 
 /**
  * AccountsApi - object-oriented interface
@@ -13,20 +14,18 @@ export class AccountsApi extends BaseAPI {
      * Returns a list of addresses seen on-chain which use the specified stake key
      * @summary Stake account addresses
      * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-     * @param {number | null} [count] The max number of results per page
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {AccountAddressesQueryParams | null} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AccountsApi
      */
     public accountAddresses(
         stakeAddr: string,
-        count?: number | null,
-        cursor?: string | null,
+        queryParams?: AccountAddressesQueryParams,
         options?: AxiosRequestConfig,
     ) {
         return AccountsApiFp(this.configuration)
-            .accountAddresses(stakeAddr, count, cursor, options)
+            .accountAddresses(stakeAddr, queryParams, options)
             .then((request) => request(this.axios));
     }
 
@@ -132,3 +131,5 @@ export class AccountsApi extends BaseAPI {
             .then((request) => request(this.axios));
     }
 }
+
+export * from './type';

--- a/src/api/accounts/index.ts
+++ b/src/api/accounts/index.ts
@@ -14,7 +14,7 @@ export class AccountsApi extends BaseAPI {
      * Returns a list of addresses seen on-chain which use the specified stake key
      * @summary Stake account addresses
      * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-     * @param {AccountAddressesQueryParams | null} [queryParams] Query parameters.
+     * @param {AccountAddressesQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AccountsApi

--- a/src/api/accounts/index.ts
+++ b/src/api/accounts/index.ts
@@ -6,6 +6,7 @@ import {
     AccountAssetsQueryParams,
     AccountHistoryQueryParams,
     AccountRewardsQueryParams,
+    AccountUpdatesQueryParams,
 } from './type';
 
 /**
@@ -97,20 +98,14 @@ export class AccountsApi extends BaseAPI {
      * Returns a list of updates relating to the specified stake key ( `registration`, `deregistration`, `delegation`, `withdrawal`)
      * @summary Stake account updates
      * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-     * @param {number | null} [count] The max number of results per page
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {AccountUpdatesQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AccountsApi
      */
-    public accountUpdates(
-        stakeAddr: string,
-        count?: number | null,
-        cursor?: string | null,
-        options?: AxiosRequestConfig,
-    ) {
+    public accountUpdates(stakeAddr: string, queryParams?: AccountUpdatesQueryParams, options?: AxiosRequestConfig) {
         return AccountsApiFp(this.configuration)
-            .accountUpdates(stakeAddr, count, cursor, options)
+            .accountUpdates(stakeAddr, queryParams, options)
             .then((request) => request(this.axios));
     }
 }

--- a/src/api/accounts/index.ts
+++ b/src/api/accounts/index.ts
@@ -1,7 +1,7 @@
 import { AxiosRequestConfig } from 'axios';
 import { BaseAPI } from '../../base';
 import { AccountsApiFp } from './helpers';
-import { AccountAddressesQueryParams, AccountAssetsQueryParams } from './type';
+import { AccountAddressesQueryParams, AccountAssetsQueryParams, AccountHistoryQueryParams } from './type';
 
 /**
  * AccountsApi - object-oriented interface
@@ -48,22 +48,14 @@ export class AccountsApi extends BaseAPI {
      * Returns per-epoch history for the specified stake key
      * @summary Stake account history
      * @param {string} stakeAddr Bech32 encoded stake/reward address (\&#39;stake1...\&#39;)
-     * @param {number | null} [epochNo] Fetch result for only a specific epoch
-     * @param {number | null} [count] The max number of results per page
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {AccountHistoryQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AccountsApi
      */
-    public accountHistory(
-        stakeAddr: string,
-        epochNo?: number | null,
-        count?: number | null,
-        cursor?: string | null,
-        options?: AxiosRequestConfig,
-    ) {
+    public accountHistory(stakeAddr: string, queryParams?: AccountHistoryQueryParams, options?: AxiosRequestConfig) {
         return AccountsApiFp(this.configuration)
-            .accountHistory(stakeAddr, epochNo, count, cursor, options)
+            .accountHistory(stakeAddr, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/accounts/index.ts
+++ b/src/api/accounts/index.ts
@@ -1,7 +1,7 @@
 import { AxiosRequestConfig } from 'axios';
 import { BaseAPI } from '../../base';
 import { AccountsApiFp } from './helpers';
-import { AccountAddressesQueryParams } from './type';
+import { AccountAddressesQueryParams, AccountAssetsQueryParams } from './type';
 
 /**
  * AccountsApi - object-oriented interface
@@ -33,22 +33,14 @@ export class AccountsApi extends BaseAPI {
      * Returns a list of native assets which are owned by addresses with the specified stake key
      * @summary Stake account assets
      * @param {string} stakeAddr Bech32 encoded reward/stake address (\&#39;stake1...\&#39;)
-     * @param {string | null} [policy] Filter results to only show assets of the specified policy
-     * @param {number | null} [count] The max number of results per page
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {AccountAssetsQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AccountsApi
      */
-    public accountAssets(
-        stakeAddr: string,
-        policy?: string | null,
-        count?: number | null,
-        cursor?: string | null,
-        options?: AxiosRequestConfig,
-    ) {
+    public accountAssets(stakeAddr: string, queryParams?: AccountAssetsQueryParams, options?: AxiosRequestConfig) {
         return AccountsApiFp(this.configuration)
-            .accountAssets(stakeAddr, policy, count, cursor, options)
+            .accountAssets(stakeAddr, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/accounts/type.ts
+++ b/src/api/accounts/type.ts
@@ -1,10 +1,20 @@
 /**
  * Query parameters for fetching account addresses.
- * @param {number | null} [count] - The max number of results per page.
- * @param {string | null} [cursor] - Pagination cursor string.
- *    Use the cursor included in a page of results to fetch the next page.
+ * @export
+ * @interface AccountHistory
+ *
  */
 export interface AccountAddressesQueryParams {
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof AccountAddressesQueryParams
+     */
     count?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof AccountAddressesQueryParams
+     */
     cursor?: string | null;
 }

--- a/src/api/accounts/type.ts
+++ b/src/api/accounts/type.ts
@@ -1,0 +1,10 @@
+/**
+ * Query parameters for fetching account addresses.
+ * @param {number | null} [count] - The max number of results per page.
+ * @param {string | null} [cursor] - Pagination cursor string.
+ *    Use the cursor included in a page of results to fetch the next page.
+ */
+export interface AccountAddressesQueryParams {
+    count?: number | null;
+    cursor?: string | null;
+}

--- a/src/api/accounts/type.ts
+++ b/src/api/accounts/type.ts
@@ -93,3 +93,24 @@ export interface AccountRewardsQueryParams {
      */
     cursor?: string | null;
 }
+
+/**
+ * Query parameters for fetching account updates.
+ * @export
+ * @interface AccountUpdatesQueryParams
+ *
+ */
+export interface AccountUpdatesQueryParams {
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof AccountUpdatesQueryParams
+     */
+    count?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof AccountUpdatesQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/accounts/type.ts
+++ b/src/api/accounts/type.ts
@@ -45,3 +45,30 @@ export interface AccountAssetsQueryParams {
      */
     cursor?: string | null;
 }
+
+/**
+ * Query parameters for fetching account history.
+ * @export
+ * @interface AccountHistoryQueryParams
+ *
+ */
+export interface AccountHistoryQueryParams {
+    /**
+     * Fetch result for only a specific epoch
+     * @type {string | null}
+     * @memberof AccountHistoryQueryParams
+     */
+    epochNo?: number | null;
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof AccountHistoryQueryParams
+     */
+    count?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof AccountHistoryQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/accounts/type.ts
+++ b/src/api/accounts/type.ts
@@ -1,7 +1,7 @@
 /**
  * Query parameters for fetching account addresses.
  * @export
- * @interface AccountHistory
+ * @interface AccountAddressesQueryParams
  *
  */
 export interface AccountAddressesQueryParams {
@@ -15,6 +15,33 @@ export interface AccountAddressesQueryParams {
      * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
      * @type {string | null}
      * @memberof AccountAddressesQueryParams
+     */
+    cursor?: string | null;
+}
+
+/**
+ * Query parameters for fetching account assets.
+ * @export
+ * @interface AccountAssetsQueryParams
+ *
+ */
+export interface AccountAssetsQueryParams {
+    /**
+     * Filter results to only show assets of the specified policy
+     * @type {string | null}
+     * @memberof AccountAssetsQueryParams
+     */
+    policy?: string | null;
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof AccountAssetsQueryParams
+     */
+    count?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof AccountAssetsQueryParams
      */
     cursor?: string | null;
 }

--- a/src/api/accounts/type.ts
+++ b/src/api/accounts/type.ts
@@ -72,3 +72,24 @@ export interface AccountHistoryQueryParams {
      */
     cursor?: string | null;
 }
+
+/**
+ * Query parameters for fetching account rewards.
+ * @export
+ * @interface AccountRewardsQueryParams
+ *
+ */
+export interface AccountRewardsQueryParams {
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof AccountRewardsQueryParams
+     */
+    count?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof AccountRewardsQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/accounts/type.ts
+++ b/src/api/accounts/type.ts
@@ -1,5 +1,5 @@
 /**
- * Query parameters for fetching account addresses.
+ * Query parameters for accountAddresses.
  * @export
  * @interface AccountAddressesQueryParams
  *
@@ -20,7 +20,7 @@ export interface AccountAddressesQueryParams {
 }
 
 /**
- * Query parameters for fetching account assets.
+ * Query parameters for accountAssets.
  * @export
  * @interface AccountAssetsQueryParams
  *
@@ -47,7 +47,7 @@ export interface AccountAssetsQueryParams {
 }
 
 /**
- * Query parameters for fetching account history.
+ * Query parameters for accountHistory.
  * @export
  * @interface AccountHistoryQueryParams
  *
@@ -74,7 +74,7 @@ export interface AccountHistoryQueryParams {
 }
 
 /**
- * Query parameters for fetching account rewards.
+ * Query parameters for accountRewards.
  * @export
  * @interface AccountRewardsQueryParams
  *
@@ -95,7 +95,7 @@ export interface AccountRewardsQueryParams {
 }
 
 /**
- * Query parameters for fetching account updates.
+ * Query parameters for accountUpdates.
  * @export
  * @interface AccountUpdatesQueryParams
  *

--- a/src/api/addresses/helpers.ts
+++ b/src/api/addresses/helpers.ts
@@ -22,6 +22,7 @@ import {
     TxsByAddressOrderEnum,
     TxsByAddressQueryParams,
     TxsByPaymentCredOrderEnum,
+    TxsByPaymentCredQueryParams,
     UtxoRefsAtAddressOrderEnum,
     UtxosByAddressOrderEnum,
     UtxosByPaymentCredOrderEnum,
@@ -155,21 +156,13 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
          * Returns transactions in which the specified payment credential spent or received funds.  Specifically, the transactions where: the payment credential was used in an address which controlled at least one of the transaction inputs and/or receives one of the outputs AND the transaction is phase-2 valid, OR, the address controlled at least one of the collateral inputs and/or receives the collateral return output AND the transaction is phase-2 invalid. [Read more](https://docs.cardano.org/plutus/collateral-mechanism/).
          * @summary Payment credential transactions
          * @param {string} credential Payment credential in bech32 format
-         * @param {number | null} [count] The max number of results per page
-         * @param {TxsByPaymentCredOrderEnum} [order] The order in which the results are sorted, by transaction age)
-         * @param {number | null} [from] Return only transactions minted on or after a specific slot
-         * @param {number | null} [to] Return only transactions minted on or before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {TxsByPaymentCredQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         txsByPaymentCred: async (
             credential: string,
-            count?: number | null,
-            order?: TxsByPaymentCredOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter: TxsByPaymentCredQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'credential' is not null or undefined
@@ -184,30 +177,9 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (order !== undefined) {
-                localVarQueryParameter.order = order;
-            }
-
-            if (from !== undefined) {
-                localVarQueryParameter.from = from;
-            }
-
-            if (to !== undefined) {
-                localVarQueryParameter.to = to;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -582,30 +554,18 @@ export const AddressesApiFp = function (configuration: Configuration) {
          * Returns transactions in which the specified payment credential spent or received funds.  Specifically, the transactions where: the payment credential was used in an address which controlled at least one of the transaction inputs and/or receives one of the outputs AND the transaction is phase-2 valid, OR, the address controlled at least one of the collateral inputs and/or receives the collateral return output AND the transaction is phase-2 invalid. [Read more](https://docs.cardano.org/plutus/collateral-mechanism/).
          * @summary Payment credential transactions
          * @param {string} credential Payment credential in bech32 format
-         * @param {number | null} [count] The max number of results per page
-         * @param {TxsByPaymentCredOrderEnum} [order] The order in which the results are sorted, by transaction age)
-         * @param {number | null} [from] Return only transactions minted on or after a specific slot
-         * @param {number | null} [to] Return only transactions minted on or before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {TxsByPaymentCredQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async txsByPaymentCred(
             credential: string,
-            count?: number | null,
-            order?: TxsByPaymentCredOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
+            queryParams?: TxsByPaymentCredQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedPaymentCredentialTransaction>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.txsByPaymentCred(
                 credential,
-                count,
-                order,
-                from,
-                to,
-                cursor,
+                queryParams,
                 options,
             );
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);

--- a/src/api/addresses/helpers.ts
+++ b/src/api/addresses/helpers.ts
@@ -19,16 +19,11 @@ import {
     PaginatedUtxoWithSlot,
 } from '../type';
 import {
-    TxsByAddressOrderEnum,
     TxsByAddressQueryParams,
-    TxsByPaymentCredOrderEnum,
     TxsByPaymentCredQueryParams,
-    UtxoRefsAtAddressOrderEnum,
     UtxoRefsAtAddressQueryParams,
-    UtxosByAddressOrderEnum,
     UtxosByAddressQueryParams,
     UtxosByAddressesQueryParams,
-    UtxosByPaymentCredOrderEnum,
     UtxosByPaymentCredQueryParams,
 } from './type';
 

--- a/src/api/addresses/helpers.ts
+++ b/src/api/addresses/helpers.ts
@@ -26,6 +26,7 @@ import {
     UtxoRefsAtAddressOrderEnum,
     UtxoRefsAtAddressQueryParams,
     UtxosByAddressOrderEnum,
+    UtxosByAddressQueryParams,
     UtxosByPaymentCredOrderEnum,
 } from './type';
 
@@ -241,25 +242,13 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
          * Return detailed information on UTxOs controlled by an address
          * @summary UTxOs at an address
          * @param {string} address Address in bech32 format
-         * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
-         * @param {boolean | null} [withCbor] Include the CBOR encodings of the transaction outputs in the response
-         * @param {number | null} [count] The max number of results per page
-         * @param {UtxosByAddressOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-         * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-         * @param {number | null} [to] Return only UTxOs created before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {UtxosByAddressQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         utxosByAddress: async (
             address: string,
-            resolveDatums?: boolean | null,
-            withCbor?: boolean | null,
-            count?: number | null,
-            order?: UtxosByAddressOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter?: UtxosByAddressQueryParams,
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'address' is not null or undefined
@@ -274,38 +263,9 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (resolveDatums !== undefined) {
-                localVarQueryParameter.resolve_datums = resolveDatums;
-            }
-
-            if (withCbor !== undefined) {
-                localVarQueryParameter.with_cbor = withCbor;
-            }
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (order !== undefined) {
-                localVarQueryParameter.order = order;
-            }
-
-            if (from !== undefined) {
-                localVarQueryParameter.from = from;
-            }
-
-            if (to !== undefined) {
-                localVarQueryParameter.to = to;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -562,38 +522,16 @@ export const AddressesApiFp = function (configuration: Configuration) {
          * Return detailed information on UTxOs controlled by an address
          * @summary UTxOs at an address
          * @param {string} address Address in bech32 format
-         * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
-         * @param {boolean | null} [withCbor] Include the CBOR encodings of the transaction outputs in the response
-         * @param {number | null} [count] The max number of results per page
-         * @param {UtxosByAddressOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-         * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-         * @param {number | null} [to] Return only UTxOs created before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {UtxosByAddressQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async utxosByAddress(
             address: string,
-            resolveDatums?: boolean | null,
-            withCbor?: boolean | null,
-            count?: number | null,
-            order?: UtxosByAddressOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
+            queryParams?: UtxosByAddressQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedUtxoWithSlot>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.utxosByAddress(
-                address,
-                resolveDatums,
-                withCbor,
-                count,
-                order,
-                from,
-                to,
-                cursor,
-                options,
-            );
+            const localVarAxiosArgs = await localVarAxiosParamCreator.utxosByAddress(address, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**

--- a/src/api/addresses/helpers.ts
+++ b/src/api/addresses/helpers.ts
@@ -29,6 +29,7 @@ import {
     UtxosByAddressQueryParams,
     UtxosByAddressesQueryParams,
     UtxosByPaymentCredOrderEnum,
+    UtxosByPaymentCredQueryParams,
 } from './type';
 
 /**
@@ -327,25 +328,13 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
          * Return detailed information on UTxOs controlled by addresses which use the specified payment credential
          * @summary UTxOs by payment credential
          * @param {string} credential Payment credential in bech32 format
-         * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
-         * @param {boolean | null} [withCbor] Include the CBOR encodings of the transaction outputs in the response
-         * @param {number | null} [count] The max number of results per page
-         * @param {UtxosByPaymentCredOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-         * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-         * @param {number | null} [to] Return only UTxOs created on or before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {UtxosByPaymentCredQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         utxosByPaymentCred: async (
             credential: string,
-            resolveDatums?: boolean | null,
-            withCbor?: boolean | null,
-            count?: number | null,
-            order?: UtxosByPaymentCredOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter: UtxosByPaymentCredQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'credential' is not null or undefined
@@ -360,38 +349,9 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (resolveDatums !== undefined) {
-                localVarQueryParameter.resolve_datums = resolveDatums;
-            }
-
-            if (withCbor !== undefined) {
-                localVarQueryParameter.with_cbor = withCbor;
-            }
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (order !== undefined) {
-                localVarQueryParameter.order = order;
-            }
-
-            if (from !== undefined) {
-                localVarQueryParameter.from = from;
-            }
-
-            if (to !== undefined) {
-                localVarQueryParameter.to = to;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -536,36 +496,18 @@ export const AddressesApiFp = function (configuration: Configuration) {
          * Return detailed information on UTxOs controlled by addresses which use the specified payment credential
          * @summary UTxOs by payment credential
          * @param {string} credential Payment credential in bech32 format
-         * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
-         * @param {boolean | null} [withCbor] Include the CBOR encodings of the transaction outputs in the response
-         * @param {number | null} [count] The max number of results per page
-         * @param {UtxosByPaymentCredOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-         * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-         * @param {number | null} [to] Return only UTxOs created on or before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {UtxosByPaymentCredQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async utxosByPaymentCred(
             credential: string,
-            resolveDatums?: boolean | null,
-            withCbor?: boolean | null,
-            count?: number | null,
-            order?: UtxosByPaymentCredOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
+            queryParams?: UtxosByPaymentCredQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedUtxoWithSlot>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.utxosByPaymentCred(
                 credential,
-                resolveDatums,
-                withCbor,
-                count,
-                order,
-                from,
-                to,
-                cursor,
+                queryParams,
                 options,
             );
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);

--- a/src/api/addresses/helpers.ts
+++ b/src/api/addresses/helpers.ts
@@ -27,6 +27,7 @@ import {
     UtxoRefsAtAddressQueryParams,
     UtxosByAddressOrderEnum,
     UtxosByAddressQueryParams,
+    UtxosByAddressesQueryParams,
     UtxosByPaymentCredOrderEnum,
 } from './type';
 
@@ -248,7 +249,7 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
          */
         utxosByAddress: async (
             address: string,
-            localVarQueryParameter?: UtxosByAddressQueryParams,
+            localVarQueryParameter: UtxosByAddressQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'address' is not null or undefined
@@ -284,19 +285,13 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
          * Return detailed information on UTxOs which are controlled by some address in the specified list of addresses
          * @summary UTxOs at multiple addresses
          * @param {Array<string>} requestBody
-         * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
-         * @param {boolean | null} [withCbor] Include the CBOR encodings of the transaction outputs in the response
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {UtxosByAddressesQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         utxosByAddresses: async (
             requestBody: Array<string>,
-            resolveDatums?: boolean | null,
-            withCbor?: boolean | null,
-            count?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter: UtxosByAddressesQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'requestBody' is not null or undefined
@@ -308,26 +303,9 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
 
             const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (resolveDatums !== undefined) {
-                localVarQueryParameter.resolve_datums = resolveDatums;
-            }
-
-            if (withCbor !== undefined) {
-                localVarQueryParameter.with_cbor = withCbor;
-            }
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             localVarHeaderParameter['Content-Type'] = 'application/json';
 
@@ -538,27 +516,18 @@ export const AddressesApiFp = function (configuration: Configuration) {
          * Return detailed information on UTxOs which are controlled by some address in the specified list of addresses
          * @summary UTxOs at multiple addresses
          * @param {Array<string>} requestBody
-         * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
-         * @param {boolean | null} [withCbor] Include the CBOR encodings of the transaction outputs in the response
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {UtxosByAddressesQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async utxosByAddresses(
             requestBody: Array<string>,
-            resolveDatums?: boolean | null,
-            withCbor?: boolean | null,
-            count?: number | null,
-            cursor?: string | null,
+            queryParams?: UtxosByAddressesQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedUtxoWithSlot>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.utxosByAddresses(
                 requestBody,
-                resolveDatums,
-                withCbor,
-                count,
-                cursor,
+                queryParams,
                 options,
             );
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);

--- a/src/api/addresses/helpers.ts
+++ b/src/api/addresses/helpers.ts
@@ -20,6 +20,7 @@ import {
 } from '../type';
 import {
     TxsByAddressOrderEnum,
+    TxsByAddressQueryParams,
     TxsByPaymentCredOrderEnum,
     UtxoRefsAtAddressOrderEnum,
     UtxosByAddressOrderEnum,
@@ -112,21 +113,13 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
          * Returns transactions in which the specified address spent or received funds.  Specifically, the transactions where: the address controlled at least one of the transaction inputs and/or receives one of the outputs AND the transaction is phase-2 valid, OR, the address controlled at least one of the collateral inputs and/or receives the collateral return output AND the transaction is phase-2 invalid. [Read more](https://docs.cardano.org/plutus/collateral-mechanism/).
          * @summary Address transactions
          * @param {string} address Address in bech32 format
-         * @param {number | null} [count] The max number of results per page
-         * @param {TxsByAddressOrderEnum} [order] The order in which the results are sorted, by transaction age)
-         * @param {number | null} [from] Return only transactions minted on or after a specific slot
-         * @param {number | null} [to] Return only transactions minted on or before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {TxsByAddressQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         txsByAddress: async (
             address: string,
-            count?: number | null,
-            order?: TxsByAddressOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter?: TxsByAddressQueryParams,
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'address' is not null or undefined
@@ -141,30 +134,9 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (order !== undefined) {
-                localVarQueryParameter.order = order;
-            }
-
-            if (from !== undefined) {
-                localVarQueryParameter.from = from;
-            }
-
-            if (to !== undefined) {
-                localVarQueryParameter.to = to;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -594,32 +566,16 @@ export const AddressesApiFp = function (configuration: Configuration) {
          * Returns transactions in which the specified address spent or received funds.  Specifically, the transactions where: the address controlled at least one of the transaction inputs and/or receives one of the outputs AND the transaction is phase-2 valid, OR, the address controlled at least one of the collateral inputs and/or receives the collateral return output AND the transaction is phase-2 invalid. [Read more](https://docs.cardano.org/plutus/collateral-mechanism/).
          * @summary Address transactions
          * @param {string} address Address in bech32 format
-         * @param {number | null} [count] The max number of results per page
-         * @param {TxsByAddressOrderEnum} [order] The order in which the results are sorted, by transaction age)
-         * @param {number | null} [from] Return only transactions minted on or after a specific slot
-         * @param {number | null} [to] Return only transactions minted on or before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {TxsByAddressQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async txsByAddress(
             address: string,
-            count?: number | null,
-            order?: TxsByAddressOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
+            queryParams?: TxsByAddressQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAddressTransaction>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.txsByAddress(
-                address,
-                count,
-                order,
-                from,
-                to,
-                cursor,
-                options,
-            );
+            const localVarAxiosArgs = await localVarAxiosParamCreator.txsByAddress(address, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**
@@ -794,188 +750,188 @@ export const AddressesApiFp = function (configuration: Configuration) {
     };
 };
 
-/**
- * AddressesApi - factory interface
- * @export
- */
-export const AddressesApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = AddressesApiFp(configuration);
-    return {
-        /**
-         * Returns the different information encoded within a Cardano address, including details of the payment and delegation parts of the address
-         * @summary Decode address
-         * @param {string} address Address in bech32/hex/base58 format
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        decodeAddress(address: string, options?: any): AxiosPromise<AddressInfo> {
-            return localVarFp.decodeAddress(address, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns the number of transactions in which the address spent or received some funds.  Specifically, the number of transactions where: the address controlled at least one of the transaction inputs and/or receives one of the outputs AND the transaction is phase-2 valid, OR, the address controlled at least one of the collateral inputs and/or receives the collateral return output AND the transaction is phase-2 invalid. [Read more](https://docs.cardano.org/plutus/collateral-mechanism/).
-         * @summary Address transaction count
-         * @param {string} address Address in bech32 format
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        txCountByAddress(address: string, options?: any): AxiosPromise<TimestampedTxCount> {
-            return localVarFp.txCountByAddress(address, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns transactions in which the specified address spent or received funds.  Specifically, the transactions where: the address controlled at least one of the transaction inputs and/or receives one of the outputs AND the transaction is phase-2 valid, OR, the address controlled at least one of the collateral inputs and/or receives the collateral return output AND the transaction is phase-2 invalid. [Read more](https://docs.cardano.org/plutus/collateral-mechanism/).
-         * @summary Address transactions
-         * @param {string} address Address in bech32 format
-         * @param {number | null} [count] The max number of results per page
-         * @param {TxsByAddressOrderEnum} [order] The order in which the results are sorted, by transaction age)
-         * @param {number | null} [from] Return only transactions minted on or after a specific slot
-         * @param {number | null} [to] Return only transactions minted on or before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        txsByAddress(
-            address: string,
-            count?: number | null,
-            order?: TxsByAddressOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedAddressTransaction> {
-            return localVarFp
-                .txsByAddress(address, count, order, from, to, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns transactions in which the specified payment credential spent or received funds.  Specifically, the transactions where: the payment credential was used in an address which controlled at least one of the transaction inputs and/or receives one of the outputs AND the transaction is phase-2 valid, OR, the address controlled at least one of the collateral inputs and/or receives the collateral return output AND the transaction is phase-2 invalid. [Read more](https://docs.cardano.org/plutus/collateral-mechanism/).
-         * @summary Payment credential transactions
-         * @param {string} credential Payment credential in bech32 format
-         * @param {number | null} [count] The max number of results per page
-         * @param {TxsByPaymentCredOrderEnum} [order] The order in which the results are sorted, by transaction age)
-         * @param {number | null} [from] Return only transactions minted on or after a specific slot
-         * @param {number | null} [to] Return only transactions minted on or before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        txsByPaymentCred(
-            credential: string,
-            count?: number | null,
-            order?: TxsByPaymentCredOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedPaymentCredentialTransaction> {
-            return localVarFp
-                .txsByPaymentCred(credential, count, order, from, to, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns references (pair of transaction hash and output index in transaction) for UTxOs controlled by the specified address
-         * @summary UTxO references at an address
-         * @param {string} address Address in bech32 format
-         * @param {number | null} [count] The max number of results per page
-         * @param {UtxoRefsAtAddressOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-         * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-         * @param {number | null} [to] Return only UTxOs created before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        utxoRefsAtAddress(
-            address: string,
-            count?: number | null,
-            order?: UtxoRefsAtAddressOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedUtxoRef> {
-            return localVarFp
-                .utxoRefsAtAddress(address, count, order, from, to, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Return detailed information on UTxOs controlled by an address
-         * @summary UTxOs at an address
-         * @param {string} address Address in bech32 format
-         * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
-         * @param {boolean | null} [withCbor] Include the CBOR encodings of the transaction outputs in the response
-         * @param {number | null} [count] The max number of results per page
-         * @param {UtxosByAddressOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-         * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-         * @param {number | null} [to] Return only UTxOs created before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        utxosByAddress(
-            address: string,
-            resolveDatums?: boolean | null,
-            withCbor?: boolean | null,
-            count?: number | null,
-            order?: UtxosByAddressOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedUtxoWithSlot> {
-            return localVarFp
-                .utxosByAddress(address, resolveDatums, withCbor, count, order, from, to, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Return detailed information on UTxOs which are controlled by some address in the specified list of addresses
-         * @summary UTxOs at multiple addresses
-         * @param {Array<string>} requestBody
-         * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
-         * @param {boolean | null} [withCbor] Include the CBOR encodings of the transaction outputs in the response
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        utxosByAddresses(
-            requestBody: Array<string>,
-            resolveDatums?: boolean | null,
-            withCbor?: boolean | null,
-            count?: number | null,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedUtxoWithSlot> {
-            return localVarFp
-                .utxosByAddresses(requestBody, resolveDatums, withCbor, count, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Return detailed information on UTxOs controlled by addresses which use the specified payment credential
-         * @summary UTxOs by payment credential
-         * @param {string} credential Payment credential in bech32 format
-         * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
-         * @param {boolean | null} [withCbor] Include the CBOR encodings of the transaction outputs in the response
-         * @param {number | null} [count] The max number of results per page
-         * @param {UtxosByPaymentCredOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-         * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-         * @param {number | null} [to] Return only UTxOs created on or before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        utxosByPaymentCred(
-            credential: string,
-            resolveDatums?: boolean | null,
-            withCbor?: boolean | null,
-            count?: number | null,
-            order?: UtxosByPaymentCredOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedUtxoWithSlot> {
-            return localVarFp
-                .utxosByPaymentCred(credential, resolveDatums, withCbor, count, order, from, to, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-    };
-};
+// /**
+//  * AddressesApi - factory interface
+//  * @export
+//  */
+// export const AddressesApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
+//     const localVarFp = AddressesApiFp(configuration);
+//     return {
+//         /**
+//          * Returns the different information encoded within a Cardano address, including details of the payment and delegation parts of the address
+//          * @summary Decode address
+//          * @param {string} address Address in bech32/hex/base58 format
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         decodeAddress(address: string, options?: any): AxiosPromise<AddressInfo> {
+//             return localVarFp.decodeAddress(address, options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns the number of transactions in which the address spent or received some funds.  Specifically, the number of transactions where: the address controlled at least one of the transaction inputs and/or receives one of the outputs AND the transaction is phase-2 valid, OR, the address controlled at least one of the collateral inputs and/or receives the collateral return output AND the transaction is phase-2 invalid. [Read more](https://docs.cardano.org/plutus/collateral-mechanism/).
+//          * @summary Address transaction count
+//          * @param {string} address Address in bech32 format
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         txCountByAddress(address: string, options?: any): AxiosPromise<TimestampedTxCount> {
+//             return localVarFp.txCountByAddress(address, options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns transactions in which the specified address spent or received funds.  Specifically, the transactions where: the address controlled at least one of the transaction inputs and/or receives one of the outputs AND the transaction is phase-2 valid, OR, the address controlled at least one of the collateral inputs and/or receives the collateral return output AND the transaction is phase-2 invalid. [Read more](https://docs.cardano.org/plutus/collateral-mechanism/).
+//          * @summary Address transactions
+//          * @param {string} address Address in bech32 format
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {TxsByAddressOrderEnum} [order] The order in which the results are sorted, by transaction age)
+//          * @param {number | null} [from] Return only transactions minted on or after a specific slot
+//          * @param {number | null} [to] Return only transactions minted on or before a specific slot
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         txsByAddress(
+//             address: string,
+//             count?: number | null,
+//             order?: TxsByAddressOrderEnum,
+//             from?: number | null,
+//             to?: number | null,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedAddressTransaction> {
+//             return localVarFp
+//                 .txsByAddress(address, count, order, from, to, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns transactions in which the specified payment credential spent or received funds.  Specifically, the transactions where: the payment credential was used in an address which controlled at least one of the transaction inputs and/or receives one of the outputs AND the transaction is phase-2 valid, OR, the address controlled at least one of the collateral inputs and/or receives the collateral return output AND the transaction is phase-2 invalid. [Read more](https://docs.cardano.org/plutus/collateral-mechanism/).
+//          * @summary Payment credential transactions
+//          * @param {string} credential Payment credential in bech32 format
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {TxsByPaymentCredOrderEnum} [order] The order in which the results are sorted, by transaction age)
+//          * @param {number | null} [from] Return only transactions minted on or after a specific slot
+//          * @param {number | null} [to] Return only transactions minted on or before a specific slot
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         txsByPaymentCred(
+//             credential: string,
+//             count?: number | null,
+//             order?: TxsByPaymentCredOrderEnum,
+//             from?: number | null,
+//             to?: number | null,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedPaymentCredentialTransaction> {
+//             return localVarFp
+//                 .txsByPaymentCred(credential, count, order, from, to, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns references (pair of transaction hash and output index in transaction) for UTxOs controlled by the specified address
+//          * @summary UTxO references at an address
+//          * @param {string} address Address in bech32 format
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {UtxoRefsAtAddressOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
+//          * @param {number | null} [from] Return only UTxOs created on or after a specific slot
+//          * @param {number | null} [to] Return only UTxOs created before a specific slot
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         utxoRefsAtAddress(
+//             address: string,
+//             count?: number | null,
+//             order?: UtxoRefsAtAddressOrderEnum,
+//             from?: number | null,
+//             to?: number | null,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedUtxoRef> {
+//             return localVarFp
+//                 .utxoRefsAtAddress(address, count, order, from, to, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Return detailed information on UTxOs controlled by an address
+//          * @summary UTxOs at an address
+//          * @param {string} address Address in bech32 format
+//          * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
+//          * @param {boolean | null} [withCbor] Include the CBOR encodings of the transaction outputs in the response
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {UtxosByAddressOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
+//          * @param {number | null} [from] Return only UTxOs created on or after a specific slot
+//          * @param {number | null} [to] Return only UTxOs created before a specific slot
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         utxosByAddress(
+//             address: string,
+//             resolveDatums?: boolean | null,
+//             withCbor?: boolean | null,
+//             count?: number | null,
+//             order?: UtxosByAddressOrderEnum,
+//             from?: number | null,
+//             to?: number | null,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedUtxoWithSlot> {
+//             return localVarFp
+//                 .utxosByAddress(address, resolveDatums, withCbor, count, order, from, to, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Return detailed information on UTxOs which are controlled by some address in the specified list of addresses
+//          * @summary UTxOs at multiple addresses
+//          * @param {Array<string>} requestBody
+//          * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
+//          * @param {boolean | null} [withCbor] Include the CBOR encodings of the transaction outputs in the response
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         utxosByAddresses(
+//             requestBody: Array<string>,
+//             resolveDatums?: boolean | null,
+//             withCbor?: boolean | null,
+//             count?: number | null,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedUtxoWithSlot> {
+//             return localVarFp
+//                 .utxosByAddresses(requestBody, resolveDatums, withCbor, count, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Return detailed information on UTxOs controlled by addresses which use the specified payment credential
+//          * @summary UTxOs by payment credential
+//          * @param {string} credential Payment credential in bech32 format
+//          * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
+//          * @param {boolean | null} [withCbor] Include the CBOR encodings of the transaction outputs in the response
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {UtxosByPaymentCredOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
+//          * @param {number | null} [from] Return only UTxOs created on or after a specific slot
+//          * @param {number | null} [to] Return only UTxOs created on or before a specific slot
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         utxosByPaymentCred(
+//             credential: string,
+//             resolveDatums?: boolean | null,
+//             withCbor?: boolean | null,
+//             count?: number | null,
+//             order?: UtxosByPaymentCredOrderEnum,
+//             from?: number | null,
+//             to?: number | null,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedUtxoWithSlot> {
+//             return localVarFp
+//                 .utxosByPaymentCred(credential, resolveDatums, withCbor, count, order, from, to, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//     };
+// };

--- a/src/api/addresses/helpers.ts
+++ b/src/api/addresses/helpers.ts
@@ -24,6 +24,7 @@ import {
     TxsByPaymentCredOrderEnum,
     TxsByPaymentCredQueryParams,
     UtxoRefsAtAddressOrderEnum,
+    UtxoRefsAtAddressQueryParams,
     UtxosByAddressOrderEnum,
     UtxosByPaymentCredOrderEnum,
 } from './type';
@@ -198,21 +199,13 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
          * Returns references (pair of transaction hash and output index in transaction) for UTxOs controlled by the specified address
          * @summary UTxO references at an address
          * @param {string} address Address in bech32 format
-         * @param {number | null} [count] The max number of results per page
-         * @param {UtxoRefsAtAddressOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-         * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-         * @param {number | null} [to] Return only UTxOs created before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {UtxoRefsAtAddressQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         utxoRefsAtAddress: async (
             address: string,
-            count?: number | null,
-            order?: UtxoRefsAtAddressOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter: UtxoRefsAtAddressQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'address' is not null or undefined
@@ -227,30 +220,9 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (order !== undefined) {
-                localVarQueryParameter.order = order;
-            }
-
-            if (from !== undefined) {
-                localVarQueryParameter.from = from;
-            }
-
-            if (to !== undefined) {
-                localVarQueryParameter.to = to;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -574,32 +546,16 @@ export const AddressesApiFp = function (configuration: Configuration) {
          * Returns references (pair of transaction hash and output index in transaction) for UTxOs controlled by the specified address
          * @summary UTxO references at an address
          * @param {string} address Address in bech32 format
-         * @param {number | null} [count] The max number of results per page
-         * @param {UtxoRefsAtAddressOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-         * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-         * @param {number | null} [to] Return only UTxOs created before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {UtxoRefsAtAddressQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async utxoRefsAtAddress(
             address: string,
-            count?: number | null,
-            order?: UtxoRefsAtAddressOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
+            queryParams?: UtxoRefsAtAddressQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedUtxoRef>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.utxoRefsAtAddress(
-                address,
-                count,
-                order,
-                from,
-                to,
-                cursor,
-                options,
-            );
+            const localVarAxiosArgs = await localVarAxiosParamCreator.utxoRefsAtAddress(address, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**

--- a/src/api/addresses/index.ts
+++ b/src/api/addresses/index.ts
@@ -7,6 +7,7 @@ import {
     UtxoRefsAtAddressOrderEnum,
     UtxosByAddressOrderEnum,
     UtxosByAddressQueryParams,
+    UtxosByAddressesQueryParams,
     UtxosByPaymentCredOrderEnum,
 } from './type';
 
@@ -113,24 +114,18 @@ export class AddressesApi extends BaseAPI {
      * Return detailed information on UTxOs which are controlled by some address in the specified list of addresses
      * @summary UTxOs at multiple addresses
      * @param {Array<string>} requestBody
-     * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
-     * @param {boolean | null} [withCbor] Include the CBOR encodings of the transaction outputs in the response
-     * @param {number | null} [count] The max number of results per page
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {UtxosByAddressesQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AddressesApi
      */
     public utxosByAddresses(
         requestBody: Array<string>,
-        resolveDatums?: boolean | null,
-        withCbor?: boolean | null,
-        count?: number | null,
-        cursor?: string | null,
+        queryParams?: UtxosByAddressesQueryParams,
         options?: AxiosRequestConfig,
     ) {
         return AddressesApiFp(this.configuration)
-            .utxosByAddresses(requestBody, resolveDatums, withCbor, count, cursor, options)
+            .utxosByAddresses(requestBody, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/addresses/index.ts
+++ b/src/api/addresses/index.ts
@@ -4,11 +4,8 @@ import { AddressesApiFp } from './helpers';
 import {
     TxsByAddressQueryParams,
     TxsByPaymentCredQueryParams,
-    UtxoRefsAtAddressOrderEnum,
-    UtxosByAddressOrderEnum,
     UtxosByAddressQueryParams,
     UtxosByAddressesQueryParams,
-    UtxosByPaymentCredOrderEnum,
     UtxosByPaymentCredQueryParams,
 } from './type';
 

--- a/src/api/addresses/index.ts
+++ b/src/api/addresses/index.ts
@@ -9,6 +9,7 @@ import {
     UtxosByAddressQueryParams,
     UtxosByAddressesQueryParams,
     UtxosByPaymentCredOrderEnum,
+    UtxosByPaymentCredQueryParams,
 } from './type';
 
 /**
@@ -133,30 +134,18 @@ export class AddressesApi extends BaseAPI {
      * Return detailed information on UTxOs controlled by addresses which use the specified payment credential
      * @summary UTxOs by payment credential
      * @param {string} credential Payment credential in bech32 format
-     * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
-     * @param {boolean | null} [withCbor] Include the CBOR encodings of the transaction outputs in the response
-     * @param {number | null} [count] The max number of results per page
-     * @param {UtxosByPaymentCredOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-     * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-     * @param {number | null} [to] Return only UTxOs created on or before a specific slot
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {UtxosByPaymentCredQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AddressesApi
      */
     public utxosByPaymentCred(
         credential: string,
-        resolveDatums?: boolean | null,
-        withCbor?: boolean | null,
-        count?: number | null,
-        order?: UtxosByPaymentCredOrderEnum,
-        from?: number | null,
-        to?: number | null,
-        cursor?: string | null,
+        queryParams?: UtxosByPaymentCredQueryParams,
         options?: AxiosRequestConfig,
     ) {
         return AddressesApiFp(this.configuration)
-            .utxosByPaymentCred(credential, resolveDatums, withCbor, count, order, from, to, cursor, options)
+            .utxosByPaymentCred(credential, queryParams, options)
             .then((request) => request(this.axios));
     }
 }

--- a/src/api/addresses/index.ts
+++ b/src/api/addresses/index.ts
@@ -2,9 +2,9 @@ import { AxiosRequestConfig } from 'axios';
 import { BaseAPI } from '../../base';
 import { AddressesApiFp } from './helpers';
 import {
-    TxsByAddressOrderEnum,
     TxsByAddressQueryParams,
     TxsByPaymentCredOrderEnum,
+    TxsByPaymentCredQueryParams,
     UtxoRefsAtAddressOrderEnum,
     UtxosByAddressOrderEnum,
     UtxosByPaymentCredOrderEnum,
@@ -64,26 +64,18 @@ export class AddressesApi extends BaseAPI {
      * Returns transactions in which the specified payment credential spent or received funds.  Specifically, the transactions where: the payment credential was used in an address which controlled at least one of the transaction inputs and/or receives one of the outputs AND the transaction is phase-2 valid, OR, the address controlled at least one of the collateral inputs and/or receives the collateral return output AND the transaction is phase-2 invalid. [Read more](https://docs.cardano.org/plutus/collateral-mechanism/).
      * @summary Payment credential transactions
      * @param {string} credential Payment credential in bech32 format
-     * @param {number | null} [count] The max number of results per page
-     * @param {TxsByPaymentCredOrderEnum} [order] The order in which the results are sorted, by transaction age)
-     * @param {number | null} [from] Return only transactions minted on or after a specific slot
-     * @param {number | null} [to] Return only transactions minted on or before a specific slot
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {TxsByPaymentCredQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AddressesApi
      */
     public txsByPaymentCred(
         credential: string,
-        count?: number | null,
-        order?: TxsByPaymentCredOrderEnum,
-        from?: number | null,
-        to?: number | null,
-        cursor?: string | null,
+        queryParams?: TxsByPaymentCredQueryParams,
         options?: AxiosRequestConfig,
     ) {
         return AddressesApiFp(this.configuration)
-            .txsByPaymentCred(credential, count, order, from, to, cursor, options)
+            .txsByPaymentCred(credential, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/addresses/index.ts
+++ b/src/api/addresses/index.ts
@@ -3,6 +3,7 @@ import { BaseAPI } from '../../base';
 import { AddressesApiFp } from './helpers';
 import {
     TxsByAddressOrderEnum,
+    TxsByAddressQueryParams,
     TxsByPaymentCredOrderEnum,
     UtxoRefsAtAddressOrderEnum,
     UtxosByAddressOrderEnum,
@@ -48,26 +49,14 @@ export class AddressesApi extends BaseAPI {
      * Returns transactions in which the specified address spent or received funds.  Specifically, the transactions where: the address controlled at least one of the transaction inputs and/or receives one of the outputs AND the transaction is phase-2 valid, OR, the address controlled at least one of the collateral inputs and/or receives the collateral return output AND the transaction is phase-2 invalid. [Read more](https://docs.cardano.org/plutus/collateral-mechanism/).
      * @summary Address transactions
      * @param {string} address Address in bech32 format
-     * @param {number | null} [count] The max number of results per page
-     * @param {TxsByAddressOrderEnum} [order] The order in which the results are sorted, by transaction age)
-     * @param {number | null} [from] Return only transactions minted on or after a specific slot
-     * @param {number | null} [to] Return only transactions minted on or before a specific slot
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {TxsByAddressQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AddressesApi
      */
-    public txsByAddress(
-        address: string,
-        count?: number | null,
-        order?: TxsByAddressOrderEnum,
-        from?: number | null,
-        to?: number | null,
-        cursor?: string | null,
-        options?: AxiosRequestConfig,
-    ) {
+    public txsByAddress(address: string, queryParams?: TxsByAddressQueryParams, options?: AxiosRequestConfig) {
         return AddressesApiFp(this.configuration)
-            .txsByAddress(address, count, order, from, to, cursor, options)
+            .txsByAddress(address, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/addresses/index.ts
+++ b/src/api/addresses/index.ts
@@ -6,6 +6,7 @@ import {
     TxsByPaymentCredQueryParams,
     UtxoRefsAtAddressOrderEnum,
     UtxosByAddressOrderEnum,
+    UtxosByAddressQueryParams,
     UtxosByPaymentCredOrderEnum,
 } from './type';
 
@@ -97,30 +98,14 @@ export class AddressesApi extends BaseAPI {
      * Return detailed information on UTxOs controlled by an address
      * @summary UTxOs at an address
      * @param {string} address Address in bech32 format
-     * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
-     * @param {boolean | null} [withCbor] Include the CBOR encodings of the transaction outputs in the response
-     * @param {number | null} [count] The max number of results per page
-     * @param {UtxosByAddressOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-     * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-     * @param {number | null} [to] Return only UTxOs created before a specific slot
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {UtxosByAddressQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AddressesApi
      */
-    public utxosByAddress(
-        address: string,
-        resolveDatums?: boolean | null,
-        withCbor?: boolean | null,
-        count?: number | null,
-        order?: UtxosByAddressOrderEnum,
-        from?: number | null,
-        to?: number | null,
-        cursor?: string | null,
-        options?: AxiosRequestConfig,
-    ) {
+    public utxosByAddress(address: string, queryParams?: UtxosByAddressQueryParams, options?: AxiosRequestConfig) {
         return AddressesApiFp(this.configuration)
-            .utxosByAddress(address, resolveDatums, withCbor, count, order, from, to, cursor, options)
+            .utxosByAddress(address, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/addresses/index.ts
+++ b/src/api/addresses/index.ts
@@ -3,7 +3,6 @@ import { BaseAPI } from '../../base';
 import { AddressesApiFp } from './helpers';
 import {
     TxsByAddressQueryParams,
-    TxsByPaymentCredOrderEnum,
     TxsByPaymentCredQueryParams,
     UtxoRefsAtAddressOrderEnum,
     UtxosByAddressOrderEnum,
@@ -83,26 +82,14 @@ export class AddressesApi extends BaseAPI {
      * Returns references (pair of transaction hash and output index in transaction) for UTxOs controlled by the specified address
      * @summary UTxO references at an address
      * @param {string} address Address in bech32 format
-     * @param {number | null} [count] The max number of results per page
-     * @param {UtxoRefsAtAddressOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-     * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-     * @param {number | null} [to] Return only UTxOs created before a specific slot
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {UtxoRefsAtAddressQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AddressesApi
      */
-    public utxoRefsAtAddress(
-        address: string,
-        count?: number | null,
-        order?: UtxoRefsAtAddressOrderEnum,
-        from?: number | null,
-        to?: number | null,
-        cursor?: string | null,
-        options?: AxiosRequestConfig,
-    ) {
+    public utxoRefsAtAddress(address: string, queryParams?: TxsByPaymentCredQueryParams, options?: AxiosRequestConfig) {
         return AddressesApiFp(this.configuration)
-            .utxoRefsAtAddress(address, count, order, from, to, cursor, options)
+            .utxoRefsAtAddress(address, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/addresses/type.ts
+++ b/src/api/addresses/type.ts
@@ -240,3 +240,54 @@ export interface UtxosByAddressesQueryParams {
      */
     cursor?: string | null;
 }
+
+/**
+ * Query parameters for utxosByPaymentCred.
+ * @export
+ * @interface UtxosByPaymentCredQueryParams
+ *
+ */
+export interface UtxosByPaymentCredQueryParams {
+    /**
+     * Try find and include the corresponding datums for datum hashes
+     * @type {boolean | null}
+     * @memberof UtxosByPaymentCredQueryParams
+     */
+    resolveDatums?: boolean | null;
+    /**
+     * Include the CBOR encodings of the transaction outputs in the response
+     * @type {boolean | null}
+     * @memberof UtxosByPaymentCredQueryParams
+     */
+    withCbor?: boolean | null;
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof UtxosByPaymentCredQueryParams
+     */
+    count?: number | null;
+    /**
+     * The order in which the results are sorted (by slot at which UTxO was produced)
+     * @type {UtxosByPaymentCredOrderEnum}
+     * @memberof UtxosByPaymentCredQueryParams
+     */
+    order?: UtxosByPaymentCredOrderEnum;
+    /**
+     * Return only UTxOs created on or after a specific slot
+     * @type {number | null}
+     * @memberof UtxosByPaymentCredQueryParams
+     */
+    from?: number | null;
+    /**
+     * Return only UTxOs created on or before a specific slot
+     * @type {number | null}
+     * @memberof UtxosByPaymentCredQueryParams
+     */
+    to?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof UtxosByPaymentCredQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/addresses/type.ts
+++ b/src/api/addresses/type.ts
@@ -156,3 +156,54 @@ export interface UtxoRefsAtAddressQueryParams {
      */
     cursor?: string | null;
 }
+
+/**
+ * Query parameters for utxoRefsAtAddress.
+ * @export
+ * @interface UtxosByAddressQueryParams
+ *
+ */
+export interface UtxosByAddressQueryParams {
+    /**
+     * Try find and include the corresponding datums for datum hashes
+     * @type {boolean | null}
+     * @memberof UtxosByAddressQueryParams
+     */
+    resolveDatums?: boolean | null;
+    /**
+     * Include the CBOR encodings of the transaction outputs in the response
+     * @type {boolean | null}
+     * @memberof UtxosByAddressQueryParams
+     */
+    withCbor?: boolean | null;
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof UtxosByAddressQueryParams
+     */
+    count?: number | null;
+    /**
+     * The order in which the results are sorted (by slot at which UTxO was produced)
+     * @type {UtxosByAddressOrderEnum}
+     * @memberof UtxosByAddressQueryParams
+     */
+    order?: UtxosByAddressOrderEnum;
+    /**
+     * Return only UTxOs created on or after a specific slot
+     * @type {number | null}
+     * @memberof UtxosByAddressQueryParams
+     */
+    from?: number | null;
+    /**
+     * Return only UTxOs created before a specific slot
+     * @type {number | null}
+     * @memberof UtxosByAddressQueryParams
+     */
+    to?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof UtxosByAddressQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/addresses/type.ts
+++ b/src/api/addresses/type.ts
@@ -39,3 +39,42 @@ export const UtxosByPaymentCredOrderEnum = {
 } as const;
 export type UtxosByPaymentCredOrderEnum =
     (typeof UtxosByPaymentCredOrderEnum)[keyof typeof UtxosByPaymentCredOrderEnum];
+
+/**
+ * Query parameters for fetching transactions by address.
+ * @export
+ * @interface TxsByAddressQueryParams
+ *
+ */
+export interface TxsByAddressQueryParams {
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof TxsByAddressQueryParams
+     */
+    count?: number | null;
+    /**
+     * The order in which the results are sorted, by transaction age
+     * @type {TxsByAddressOrderEnum}
+     * @memberof TxsByAddressQueryParams
+     */
+    order?: TxsByAddressOrderEnum;
+    /**
+     * Return only transactions minted on or after a specific slot
+     * @type {number | null}
+     * @memberof TxsByAddressQueryParams
+     */
+    from?: number | null;
+    /**
+     * Return only transactions minted on or before a specific slot
+     * @type {number | null}
+     * @memberof TxsByAddressQueryParams
+     */
+    to?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof TxsByAddressQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/addresses/type.ts
+++ b/src/api/addresses/type.ts
@@ -41,7 +41,7 @@ export type UtxosByPaymentCredOrderEnum =
     (typeof UtxosByPaymentCredOrderEnum)[keyof typeof UtxosByPaymentCredOrderEnum];
 
 /**
- * Query parameters for fetching transactions by address.
+ * Query parameters for txsByAddress.
  * @export
  * @interface TxsByAddressQueryParams
  *
@@ -80,7 +80,7 @@ export interface TxsByAddressQueryParams {
 }
 
 /**
- * Query parameters for fetching transactions by payment credential.
+ * Query parameters for txsByPaymentCred.
  * @export
  * @interface TxsByPaymentCredQueryParams
  *
@@ -94,7 +94,7 @@ export interface TxsByPaymentCredQueryParams {
     count?: number | null;
     /**
      * The order in which the results are sorted, by transaction age
-     * @type {TxsByAddressOrderEnum}
+     * @type {TxsByPaymentCredOrderEnum}
      * @memberof TxsByPaymentCredQueryParams
      */
     order?: TxsByPaymentCredOrderEnum;
@@ -114,6 +114,45 @@ export interface TxsByPaymentCredQueryParams {
      * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
      * @type {string | null}
      * @memberof TxsByPaymentCredQueryParams
+     */
+    cursor?: string | null;
+}
+
+/**
+ * Query parameters for utxoRefsAtAddress.
+ * @export
+ * @interface UtxoRefsAtAddressQueryParams
+ *
+ */
+export interface UtxoRefsAtAddressQueryParams {
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof UtxoRefsAtAddressQueryParams
+     */
+    count?: number | null;
+    /**
+     * The order in which the results are sorted (by slot at which UTxO was produced)
+     * @type {UtxoRefsAtAddressOrderEnum}
+     * @memberof UtxoRefsAtAddressQueryParams
+     */
+    order?: UtxoRefsAtAddressOrderEnum;
+    /**
+     * Return only UTxOs created on or after a specific slot
+     * @type {number | null}
+     * @memberof UtxoRefsAtAddressQueryParams
+     */
+    from?: number | null;
+    /**
+     * Return only UTxOs created before a specific slot
+     * @type {number | null}
+     * @memberof UtxoRefsAtAddressQueryParams
+     */
+    to?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof UtxoRefsAtAddressQueryParams
      */
     cursor?: string | null;
 }

--- a/src/api/addresses/type.ts
+++ b/src/api/addresses/type.ts
@@ -165,6 +165,12 @@ export interface UtxoRefsAtAddressQueryParams {
  */
 export interface UtxosByAddressQueryParams {
     /**
+     * Return only UTxOs which contain some of a specific asset (asset formatted as concatenation of hex encoded policy and asset name)
+     * @type {string | null}
+     * @memberof UtxosByAddressQueryParams
+     */
+    asset?: string | null;
+    /**
      * Try find and include the corresponding datums for datum hashes
      * @type {boolean | null}
      * @memberof UtxosByAddressQueryParams
@@ -248,6 +254,12 @@ export interface UtxosByAddressesQueryParams {
  *
  */
 export interface UtxosByPaymentCredQueryParams {
+    /**
+     * Return only UTxOs which contain some of a specific asset (asset formatted as concatenation of hex encoded policy and asset name)
+     * @type {string | null}
+     * @memberof UtxosByAddressQueryParams
+     */
+    asset?: string | null;
     /**
      * Try find and include the corresponding datums for datum hashes
      * @type {boolean | null}

--- a/src/api/addresses/type.ts
+++ b/src/api/addresses/type.ts
@@ -158,7 +158,7 @@ export interface UtxoRefsAtAddressQueryParams {
 }
 
 /**
- * Query parameters for utxoRefsAtAddress.
+ * Query parameters for utxosByAddress.
  * @export
  * @interface UtxosByAddressQueryParams
  *
@@ -204,6 +204,39 @@ export interface UtxosByAddressQueryParams {
      * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
      * @type {string | null}
      * @memberof UtxosByAddressQueryParams
+     */
+    cursor?: string | null;
+}
+
+/**
+ * Query parameters for utxosByAddresses.
+ * @export
+ * @interface UtxosByAddressesQueryParams
+ *
+ */
+export interface UtxosByAddressesQueryParams {
+    /**
+     * Try find and include the corresponding datums for datum hashes
+     * @type {boolean | null}
+     * @memberof UtxosByAddressesQueryParams
+     */
+    resolveDatums?: boolean | null;
+    /**
+     * Include the CBOR encodings of the transaction outputs in the response
+     * @type {boolean | null}
+     * @memberof UtxosByAddressesQueryParams
+     */
+    withCbor?: boolean | null;
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof UtxosByAddressesQueryParams
+     */
+    count?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof UtxosByAddressesQueryParams
      */
     cursor?: string | null;
 }

--- a/src/api/addresses/type.ts
+++ b/src/api/addresses/type.ts
@@ -78,3 +78,42 @@ export interface TxsByAddressQueryParams {
      */
     cursor?: string | null;
 }
+
+/**
+ * Query parameters for fetching transactions by payment credential.
+ * @export
+ * @interface TxsByPaymentCredQueryParams
+ *
+ */
+export interface TxsByPaymentCredQueryParams {
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof TxsByPaymentCredQueryParams
+     */
+    count?: number | null;
+    /**
+     * The order in which the results are sorted, by transaction age
+     * @type {TxsByAddressOrderEnum}
+     * @memberof TxsByPaymentCredQueryParams
+     */
+    order?: TxsByPaymentCredOrderEnum;
+    /**
+     * Return only transactions minted on or after a specific slot
+     * @type {number | null}
+     * @memberof TxsByPaymentCredQueryParams
+     */
+    from?: number | null;
+    /**
+     * Return only transactions minted on or before a specific slot
+     * @type {number | null}
+     * @memberof TxsByPaymentCredQueryParams
+     */
+    to?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof TxsByPaymentCredQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/assets/helpers.ts
+++ b/src/api/assets/helpers.ts
@@ -29,6 +29,7 @@ import {
     AssetUtxosQueryParams,
     PolicyAccountsQueryParams,
     PolicyAddressesQueryParams,
+    PolicyInfoQueryParams,
     PolicyTxsOrderEnum,
     PolicyUtxosOrderEnum,
 } from './type';
@@ -357,15 +358,13 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
          * Returns information about assets of the specified minting policy ID
          * @summary Information on assets of specific policy
          * @param {string} policy Hex encoded policy ID
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {PolicyInfoQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         policyInfo: async (
             policy: string,
-            count?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter: PolicyInfoQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'policy' is not null or undefined
@@ -377,18 +376,9 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -679,18 +669,16 @@ export const AssetsApiFp = function (configuration: Configuration) {
          * Returns information about assets of the specified minting policy ID
          * @summary Information on assets of specific policy
          * @param {string} policy Hex encoded policy ID
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {PolicyInfoQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async policyInfo(
             policy: string,
-            count?: number | null,
-            cursor?: string | null,
+            queryParams?: PolicyInfoQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAssetInfo>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.policyInfo(policy, count, cursor, options);
+            const localVarAxiosArgs = await localVarAxiosParamCreator.policyInfo(policy, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**

--- a/src/api/assets/helpers.ts
+++ b/src/api/assets/helpers.ts
@@ -24,9 +24,8 @@ import {
 import {
     AssetAccountsQueryParams,
     AssetAddressesQueryParams,
-    AssetTxsOrderEnum,
     AssetTxsQueryParams,
-    AssetUpdatesOrderEnum,
+    AssetUpdatesQueryParams,
     AssetUtxosOrderEnum,
     PolicyTxsOrderEnum,
     PolicyUtxosOrderEnum,
@@ -194,17 +193,13 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
          * Returns a list of transactions in which some of the specified asset was minted or burned
          * @summary Native asset updates
          * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-         * @param {number | null} [count] The max number of results per page
-         * @param {AssetUpdatesOrderEnum} [order] The order in which the results are sorted (by block height)
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AssetUpdatesQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         assetUpdates: async (
             asset: string,
-            count?: number | null,
-            order?: AssetUpdatesOrderEnum,
-            cursor?: string | null,
+            localVarQueryParameter: AssetUpdatesQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'asset' is not null or undefined
@@ -216,22 +211,9 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (order !== undefined) {
-                localVarQueryParameter.order = order;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -688,26 +670,16 @@ export const AssetsApiFp = function (configuration: Configuration) {
          * Returns a list of transactions in which some of the specified asset was minted or burned
          * @summary Native asset updates
          * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-         * @param {number | null} [count] The max number of results per page
-         * @param {AssetUpdatesOrderEnum} [order] The order in which the results are sorted (by block height)
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AssetUpdatesQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async assetUpdates(
             asset: string,
-            count?: number | null,
-            order?: AssetUpdatesOrderEnum,
-            cursor?: string | null,
+            queryParams?: AssetUpdatesQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedMintingTx>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.assetUpdates(
-                asset,
-                count,
-                order,
-                cursor,
-                options,
-            );
+            const localVarAxiosArgs = await localVarAxiosParamCreator.assetUpdates(asset, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**

--- a/src/api/assets/helpers.ts
+++ b/src/api/assets/helpers.ts
@@ -27,6 +27,7 @@ import {
     AssetTxsQueryParams,
     AssetUpdatesQueryParams,
     AssetUtxosQueryParams,
+    PolicyAccountsQueryParams,
     PolicyTxsOrderEnum,
     PolicyUtxosOrderEnum,
 } from './type';
@@ -271,15 +272,13 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
          * Returns a list of accounts (as stake/reward addresses) associated with addresses which control some of an asset of the specified policy; in other words, instead of returning the addresses which hold the assets, the addresses are merged by their delegation part/account. Assets controlled by Byron, enterprise, or pointer addresses are omitted.  CAUTION: An asset being associated with a particular stake account does not necessarily mean the owner of that account controls the asset; use \"asset addresses\" unless you are sure you want to work with stake keys. Read more [here]( https://medium.com/adamant-security/multi-sig-concerns-mangled-addresses-and-the-dangers-of-using-stake-keys-in-your-cardano-project-94894319b1d8).
          * @summary Accounts of addresses holding assets of specific policy
          * @param {string} policy Hex encoded Policy ID
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {PolicyAccountsQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         policyAccounts: async (
             policy: string,
-            count?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter: PolicyAccountsQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'policy' is not null or undefined
@@ -294,18 +293,9 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -667,18 +657,16 @@ export const AssetsApiFp = function (configuration: Configuration) {
          * Returns a list of accounts (as stake/reward addresses) associated with addresses which control some of an asset of the specified policy; in other words, instead of returning the addresses which hold the assets, the addresses are merged by their delegation part/account. Assets controlled by Byron, enterprise, or pointer addresses are omitted.  CAUTION: An asset being associated with a particular stake account does not necessarily mean the owner of that account controls the asset; use \"asset addresses\" unless you are sure you want to work with stake keys. Read more [here]( https://medium.com/adamant-security/multi-sig-concerns-mangled-addresses-and-the-dangers-of-using-stake-keys-in-your-cardano-project-94894319b1d8).
          * @summary Accounts of addresses holding assets of specific policy
          * @param {string} policy Hex encoded Policy ID
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {PolicyAccountsQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async policyAccounts(
             policy: string,
-            count?: number | null,
-            cursor?: string | null,
+            queryParams?: PolicyAccountsQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedPolicyHolderAccount>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.policyAccounts(policy, count, cursor, options);
+            const localVarAxiosArgs = await localVarAxiosParamCreator.policyAccounts(policy, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**

--- a/src/api/assets/helpers.ts
+++ b/src/api/assets/helpers.ts
@@ -22,6 +22,7 @@ import {
     PaginatedPolicyUtxo,
 } from '../type';
 import {
+    AssetAccountsQueryParams,
     AssetTxsOrderEnum,
     AssetUpdatesOrderEnum,
     AssetUtxosOrderEnum,
@@ -39,15 +40,13 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
          * Returns a list of accounts (as stake/reward addresses) associated with addresses which control some of the specified asset; in other words, instead of returning the addresses which hold some of the asset, the addresses are merged by their delegation part/account. Assets controlled by Byron, enterprise, or pointer addresses are omitted.  CAUTION: An asset being associated with a particular stake account does not necessarily mean the owner of that account controls the asset; use \"asset addresses\" unless you are sure you want to work with stake keys. Read more [here]( https://medium.com/adamant-security/multi-sig-concerns-mangled-addresses-and-the-dangers-of-using-stake-keys-in-your-cardano-project-94894319b1d8).
          * @summary Accounts of addresses holding specific asset
          * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AssetAccountsQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         assetAccounts: async (
             asset: string,
-            count?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter: AssetAccountsQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'asset' is not null or undefined
@@ -59,18 +58,9 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -668,18 +658,16 @@ export const AssetsApiFp = function (configuration: Configuration) {
          * Returns a list of accounts (as stake/reward addresses) associated with addresses which control some of the specified asset; in other words, instead of returning the addresses which hold some of the asset, the addresses are merged by their delegation part/account. Assets controlled by Byron, enterprise, or pointer addresses are omitted.  CAUTION: An asset being associated with a particular stake account does not necessarily mean the owner of that account controls the asset; use \"asset addresses\" unless you are sure you want to work with stake keys. Read more [here]( https://medium.com/adamant-security/multi-sig-concerns-mangled-addresses-and-the-dangers-of-using-stake-keys-in-your-cardano-project-94894319b1d8).
          * @summary Accounts of addresses holding specific asset
          * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AssetAccountsQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async assetAccounts(
             asset: string,
-            count?: number | null,
-            cursor?: string | null,
+            queryParams?: AssetAccountsQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAssetHolderAccount>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.assetAccounts(asset, count, cursor, options);
+            const localVarAxiosArgs = await localVarAxiosParamCreator.assetAccounts(asset, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**
@@ -922,230 +910,230 @@ export const AssetsApiFp = function (configuration: Configuration) {
     };
 };
 
-/**
- * AssetsApi - factory interface
- * @export
- */
-export const AssetsApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = AssetsApiFp(configuration);
-    return {
-        /**
-         * Returns a list of accounts (as stake/reward addresses) associated with addresses which control some of the specified asset; in other words, instead of returning the addresses which hold some of the asset, the addresses are merged by their delegation part/account. Assets controlled by Byron, enterprise, or pointer addresses are omitted.  CAUTION: An asset being associated with a particular stake account does not necessarily mean the owner of that account controls the asset; use \"asset addresses\" unless you are sure you want to work with stake keys. Read more [here]( https://medium.com/adamant-security/multi-sig-concerns-mangled-addresses-and-the-dangers-of-using-stake-keys-in-your-cardano-project-94894319b1d8).
-         * @summary Accounts of addresses holding specific asset
-         * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        assetAccounts(
-            asset: string,
-            count?: number | null,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedAssetHolderAccount> {
-            return localVarFp.assetAccounts(asset, count, cursor, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns a list of addresses which control some amount of the specified asset
-         * @summary Native asset addresses
-         * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        assetAddresses(
-            asset: string,
-            count?: number | null,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedAssetHolder> {
-            return localVarFp.assetAddresses(asset, count, cursor, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Return a summary of information about an asset
-         * @summary Native asset information
-         * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        assetInfo(asset: string, options?: any): AxiosPromise<TimestampedAssetInfo> {
-            return localVarFp.assetInfo(asset, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns a list of transactions in which a transaction input or output contains some of the specified asset
-         * @summary Native asset transactions
-         * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-         * @param {number | null} [fromHeight] Return only transactions after supplied block height
-         * @param {number | null} [count] The max number of results per page
-         * @param {AssetTxsOrderEnum} [order] The order in which the results are sorted (by block height)
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        assetTxs(
-            asset: string,
-            fromHeight?: number | null,
-            count?: number | null,
-            order?: AssetTxsOrderEnum,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedAssetTx> {
-            return localVarFp
-                .assetTxs(asset, fromHeight, count, order, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns a list of transactions in which some of the specified asset was minted or burned
-         * @summary Native asset updates
-         * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-         * @param {number | null} [count] The max number of results per page
-         * @param {AssetUpdatesOrderEnum} [order] The order in which the results are sorted (by block height)
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        assetUpdates(
-            asset: string,
-            count?: number | null,
-            order?: AssetUpdatesOrderEnum,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedMintingTx> {
-            return localVarFp
-                .assetUpdates(asset, count, order, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns references for UTxOs which contain some of the specified asset, each paired with the amount of the asset contained in the UTxO
-         * @summary Native asset UTxOs
-         * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-         * @param {string | null} [address] Return only UTxOs controlled by a specific address (bech32 encoding)
-         * @param {number | null} [count] The max number of results per page
-         * @param {AssetUtxosOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-         * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-         * @param {number | null} [to] Return only UTxOs created before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        assetUtxos(
-            asset: string,
-            address?: string | null,
-            count?: number | null,
-            order?: AssetUtxosOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedAssetUtxo> {
-            return localVarFp
-                .assetUtxos(asset, address, count, order, from, to, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns a list of accounts (as stake/reward addresses) associated with addresses which control some of an asset of the specified policy; in other words, instead of returning the addresses which hold the assets, the addresses are merged by their delegation part/account. Assets controlled by Byron, enterprise, or pointer addresses are omitted.  CAUTION: An asset being associated with a particular stake account does not necessarily mean the owner of that account controls the asset; use \"asset addresses\" unless you are sure you want to work with stake keys. Read more [here]( https://medium.com/adamant-security/multi-sig-concerns-mangled-addresses-and-the-dangers-of-using-stake-keys-in-your-cardano-project-94894319b1d8).
-         * @summary Accounts of addresses holding assets of specific policy
-         * @param {string} policy Hex encoded Policy ID
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        policyAccounts(
-            policy: string,
-            count?: number | null,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedPolicyHolderAccount> {
-            return localVarFp
-                .policyAccounts(policy, count, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns a list of addresses which hold some of an asset of the specified policy ID
-         * @summary Addresses holding assets of specific policy
-         * @param {string} policy Hex encoded Policy ID
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        policyAddresses(
-            policy: string,
-            count?: number | null,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedPolicyHolder> {
-            return localVarFp
-                .policyAddresses(policy, count, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns information about assets of the specified minting policy ID
-         * @summary Information on assets of specific policy
-         * @param {string} policy Hex encoded policy ID
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        policyInfo(
-            policy: string,
-            count?: number | null,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedAssetInfo> {
-            return localVarFp.policyInfo(policy, count, cursor, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns a list of transactions in which a transaction input or output contains some of at least one asset of the specified minting policy ID
-         * @summary Transactions moving assets of specific policy
-         * @param {string} policy Hex encoded policy ID
-         * @param {number | null} [fromHeight] Return only transactions after supplied block height
-         * @param {number | null} [count] The max number of results per page
-         * @param {PolicyTxsOrderEnum} [order] The order in which the results are sorted (by block height)
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        policyTxs(
-            policy: string,
-            fromHeight?: number | null,
-            count?: number | null,
-            order?: PolicyTxsOrderEnum,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedAssetTx> {
-            return localVarFp
-                .policyTxs(policy, fromHeight, count, order, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns UTxO references of UTxOs which contain some of at least one asset of the specified policy ID, each paired with a list of assets of the policy contained in the UTxO and the corresponding amounts
-         * @summary UTxOs containing assets of specific policy
-         * @param {string} policy Hex encoded policy ID
-         * @param {number | null} [count] The max number of results per page
-         * @param {PolicyUtxosOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-         * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-         * @param {number | null} [to] Return only UTxOs created before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        policyUtxos(
-            policy: string,
-            count?: number | null,
-            order?: PolicyUtxosOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedPolicyUtxo> {
-            return localVarFp
-                .policyUtxos(policy, count, order, from, to, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-    };
-};
+// /**
+//  * AssetsApi - factory interface
+//  * @export
+//  */
+// export const AssetsApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
+//     const localVarFp = AssetsApiFp(configuration);
+//     return {
+//         /**
+//          * Returns a list of accounts (as stake/reward addresses) associated with addresses which control some of the specified asset; in other words, instead of returning the addresses which hold some of the asset, the addresses are merged by their delegation part/account. Assets controlled by Byron, enterprise, or pointer addresses are omitted.  CAUTION: An asset being associated with a particular stake account does not necessarily mean the owner of that account controls the asset; use \"asset addresses\" unless you are sure you want to work with stake keys. Read more [here]( https://medium.com/adamant-security/multi-sig-concerns-mangled-addresses-and-the-dangers-of-using-stake-keys-in-your-cardano-project-94894319b1d8).
+//          * @summary Accounts of addresses holding specific asset
+//          * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         assetAccounts(
+//             asset: string,
+//             count?: number | null,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedAssetHolderAccount> {
+//             return localVarFp.assetAccounts(asset, count, cursor, options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns a list of addresses which control some amount of the specified asset
+//          * @summary Native asset addresses
+//          * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         assetAddresses(
+//             asset: string,
+//             count?: number | null,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedAssetHolder> {
+//             return localVarFp.assetAddresses(asset, count, cursor, options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Return a summary of information about an asset
+//          * @summary Native asset information
+//          * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         assetInfo(asset: string, options?: any): AxiosPromise<TimestampedAssetInfo> {
+//             return localVarFp.assetInfo(asset, options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns a list of transactions in which a transaction input or output contains some of the specified asset
+//          * @summary Native asset transactions
+//          * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
+//          * @param {number | null} [fromHeight] Return only transactions after supplied block height
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {AssetTxsOrderEnum} [order] The order in which the results are sorted (by block height)
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         assetTxs(
+//             asset: string,
+//             fromHeight?: number | null,
+//             count?: number | null,
+//             order?: AssetTxsOrderEnum,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedAssetTx> {
+//             return localVarFp
+//                 .assetTxs(asset, fromHeight, count, order, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns a list of transactions in which some of the specified asset was minted or burned
+//          * @summary Native asset updates
+//          * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {AssetUpdatesOrderEnum} [order] The order in which the results are sorted (by block height)
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         assetUpdates(
+//             asset: string,
+//             count?: number | null,
+//             order?: AssetUpdatesOrderEnum,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedMintingTx> {
+//             return localVarFp
+//                 .assetUpdates(asset, count, order, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns references for UTxOs which contain some of the specified asset, each paired with the amount of the asset contained in the UTxO
+//          * @summary Native asset UTxOs
+//          * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
+//          * @param {string | null} [address] Return only UTxOs controlled by a specific address (bech32 encoding)
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {AssetUtxosOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
+//          * @param {number | null} [from] Return only UTxOs created on or after a specific slot
+//          * @param {number | null} [to] Return only UTxOs created before a specific slot
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         assetUtxos(
+//             asset: string,
+//             address?: string | null,
+//             count?: number | null,
+//             order?: AssetUtxosOrderEnum,
+//             from?: number | null,
+//             to?: number | null,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedAssetUtxo> {
+//             return localVarFp
+//                 .assetUtxos(asset, address, count, order, from, to, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns a list of accounts (as stake/reward addresses) associated with addresses which control some of an asset of the specified policy; in other words, instead of returning the addresses which hold the assets, the addresses are merged by their delegation part/account. Assets controlled by Byron, enterprise, or pointer addresses are omitted.  CAUTION: An asset being associated with a particular stake account does not necessarily mean the owner of that account controls the asset; use \"asset addresses\" unless you are sure you want to work with stake keys. Read more [here]( https://medium.com/adamant-security/multi-sig-concerns-mangled-addresses-and-the-dangers-of-using-stake-keys-in-your-cardano-project-94894319b1d8).
+//          * @summary Accounts of addresses holding assets of specific policy
+//          * @param {string} policy Hex encoded Policy ID
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         policyAccounts(
+//             policy: string,
+//             count?: number | null,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedPolicyHolderAccount> {
+//             return localVarFp
+//                 .policyAccounts(policy, count, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns a list of addresses which hold some of an asset of the specified policy ID
+//          * @summary Addresses holding assets of specific policy
+//          * @param {string} policy Hex encoded Policy ID
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         policyAddresses(
+//             policy: string,
+//             count?: number | null,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedPolicyHolder> {
+//             return localVarFp
+//                 .policyAddresses(policy, count, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns information about assets of the specified minting policy ID
+//          * @summary Information on assets of specific policy
+//          * @param {string} policy Hex encoded policy ID
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         policyInfo(
+//             policy: string,
+//             count?: number | null,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedAssetInfo> {
+//             return localVarFp.policyInfo(policy, count, cursor, options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns a list of transactions in which a transaction input or output contains some of at least one asset of the specified minting policy ID
+//          * @summary Transactions moving assets of specific policy
+//          * @param {string} policy Hex encoded policy ID
+//          * @param {number | null} [fromHeight] Return only transactions after supplied block height
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {PolicyTxsOrderEnum} [order] The order in which the results are sorted (by block height)
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         policyTxs(
+//             policy: string,
+//             fromHeight?: number | null,
+//             count?: number | null,
+//             order?: PolicyTxsOrderEnum,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedAssetTx> {
+//             return localVarFp
+//                 .policyTxs(policy, fromHeight, count, order, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns UTxO references of UTxOs which contain some of at least one asset of the specified policy ID, each paired with a list of assets of the policy contained in the UTxO and the corresponding amounts
+//          * @summary UTxOs containing assets of specific policy
+//          * @param {string} policy Hex encoded policy ID
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {PolicyUtxosOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
+//          * @param {number | null} [from] Return only UTxOs created on or after a specific slot
+//          * @param {number | null} [to] Return only UTxOs created before a specific slot
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         policyUtxos(
+//             policy: string,
+//             count?: number | null,
+//             order?: PolicyUtxosOrderEnum,
+//             from?: number | null,
+//             to?: number | null,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedPolicyUtxo> {
+//             return localVarFp
+//                 .policyUtxos(policy, count, order, from, to, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//     };
+// };

--- a/src/api/assets/helpers.ts
+++ b/src/api/assets/helpers.ts
@@ -25,6 +25,7 @@ import {
     AssetAccountsQueryParams,
     AssetAddressesQueryParams,
     AssetTxsOrderEnum,
+    AssetTxsQueryParams,
     AssetUpdatesOrderEnum,
     AssetUtxosOrderEnum,
     PolicyTxsOrderEnum,
@@ -154,19 +155,13 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
          * Returns a list of transactions in which a transaction input or output contains some of the specified asset
          * @summary Native asset transactions
          * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-         * @param {number | null} [fromHeight] Return only transactions after supplied block height
-         * @param {number | null} [count] The max number of results per page
-         * @param {AssetTxsOrderEnum} [order] The order in which the results are sorted (by block height)
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AssetTxsQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         assetTxs: async (
             asset: string,
-            fromHeight?: number | null,
-            count?: number | null,
-            order?: AssetTxsOrderEnum,
-            cursor?: string | null,
+            localVarQueryParameter: AssetTxsQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'asset' is not null or undefined
@@ -178,26 +173,9 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (fromHeight !== undefined) {
-                localVarQueryParameter.from_height = fromHeight;
-            }
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (order !== undefined) {
-                localVarQueryParameter.order = order;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -694,29 +672,16 @@ export const AssetsApiFp = function (configuration: Configuration) {
          * Returns a list of transactions in which a transaction input or output contains some of the specified asset
          * @summary Native asset transactions
          * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-         * @param {number | null} [fromHeight] Return only transactions after supplied block height
-         * @param {number | null} [count] The max number of results per page
-         * @param {AssetTxsOrderEnum} [order] The order in which the results are sorted (by block height)
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AssetTxsQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async assetTxs(
             asset: string,
-            fromHeight?: number | null,
-            count?: number | null,
-            order?: AssetTxsOrderEnum,
-            cursor?: string | null,
+            queryParams?: AssetTxsQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAssetTx>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.assetTxs(
-                asset,
-                fromHeight,
-                count,
-                order,
-                cursor,
-                options,
-            );
+            const localVarAxiosArgs = await localVarAxiosParamCreator.assetTxs(asset, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**

--- a/src/api/assets/helpers.ts
+++ b/src/api/assets/helpers.ts
@@ -30,9 +30,8 @@ import {
     PolicyAccountsQueryParams,
     PolicyAddressesQueryParams,
     PolicyInfoQueryParams,
-    PolicyTxsOrderEnum,
     PolicyTxsQueryParams,
-    PolicyUtxosOrderEnum,
+    PolicyUtxosQueryParams,
 } from './type';
 
 /**
@@ -440,21 +439,13 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
          * Returns UTxO references of UTxOs which contain some of at least one asset of the specified policy ID, each paired with a list of assets of the policy contained in the UTxO and the corresponding amounts
          * @summary UTxOs containing assets of specific policy
          * @param {string} policy Hex encoded policy ID
-         * @param {number | null} [count] The max number of results per page
-         * @param {PolicyUtxosOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-         * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-         * @param {number | null} [to] Return only UTxOs created before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {PolicyUtxosQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         policyUtxos: async (
             policy: string,
-            count?: number | null,
-            order?: PolicyUtxosOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter: PolicyUtxosQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'policy' is not null or undefined
@@ -469,30 +460,9 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (order !== undefined) {
-                localVarQueryParameter.order = order;
-            }
-
-            if (from !== undefined) {
-                localVarQueryParameter.from = from;
-            }
-
-            if (to !== undefined) {
-                localVarQueryParameter.to = to;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -679,32 +649,16 @@ export const AssetsApiFp = function (configuration: Configuration) {
          * Returns UTxO references of UTxOs which contain some of at least one asset of the specified policy ID, each paired with a list of assets of the policy contained in the UTxO and the corresponding amounts
          * @summary UTxOs containing assets of specific policy
          * @param {string} policy Hex encoded policy ID
-         * @param {number | null} [count] The max number of results per page
-         * @param {PolicyUtxosOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-         * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-         * @param {number | null} [to] Return only UTxOs created before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {PolicyUtxosQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async policyUtxos(
             policy: string,
-            count?: number | null,
-            order?: PolicyUtxosOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
+            queryParams?: PolicyUtxosQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedPolicyUtxo>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.policyUtxos(
-                policy,
-                count,
-                order,
-                from,
-                to,
-                cursor,
-                options,
-            );
+            const localVarAxiosArgs = await localVarAxiosParamCreator.policyUtxos(policy, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
     };

--- a/src/api/assets/helpers.ts
+++ b/src/api/assets/helpers.ts
@@ -23,6 +23,7 @@ import {
 } from '../type';
 import {
     AssetAccountsQueryParams,
+    AssetAddressesQueryParams,
     AssetTxsOrderEnum,
     AssetUpdatesOrderEnum,
     AssetUtxosOrderEnum,
@@ -40,7 +41,7 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
          * Returns a list of accounts (as stake/reward addresses) associated with addresses which control some of the specified asset; in other words, instead of returning the addresses which hold some of the asset, the addresses are merged by their delegation part/account. Assets controlled by Byron, enterprise, or pointer addresses are omitted.  CAUTION: An asset being associated with a particular stake account does not necessarily mean the owner of that account controls the asset; use \"asset addresses\" unless you are sure you want to work with stake keys. Read more [here]( https://medium.com/adamant-security/multi-sig-concerns-mangled-addresses-and-the-dangers-of-using-stake-keys-in-your-cardano-project-94894319b1d8).
          * @summary Accounts of addresses holding specific asset
          * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-         * @param {AssetAccountsQueryParams} [queryParams] Query parameters.
+         * @param {AssetAccountsQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -79,15 +80,13 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
          * Returns a list of addresses which control some amount of the specified asset
          * @summary Native asset addresses
          * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AssetAddressesQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         assetAddresses: async (
             asset: string,
-            count?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter: AssetAddressesQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'asset' is not null or undefined
@@ -99,18 +98,9 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -674,18 +664,16 @@ export const AssetsApiFp = function (configuration: Configuration) {
          * Returns a list of addresses which control some amount of the specified asset
          * @summary Native asset addresses
          * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AssetAddressesQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async assetAddresses(
             asset: string,
-            count?: number | null,
-            cursor?: string | null,
+            queryParams?: AssetAddressesQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAssetHolder>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.assetAddresses(asset, count, cursor, options);
+            const localVarAxiosArgs = await localVarAxiosParamCreator.assetAddresses(asset, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**

--- a/src/api/assets/helpers.ts
+++ b/src/api/assets/helpers.ts
@@ -26,7 +26,7 @@ import {
     AssetAddressesQueryParams,
     AssetTxsQueryParams,
     AssetUpdatesQueryParams,
-    AssetUtxosOrderEnum,
+    AssetUtxosQueryParams,
     PolicyTxsOrderEnum,
     PolicyUtxosOrderEnum,
 } from './type';
@@ -232,23 +232,13 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
          * Returns references for UTxOs which contain some of the specified asset, each paired with the amount of the asset contained in the UTxO
          * @summary Native asset UTxOs
          * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-         * @param {string | null} [address] Return only UTxOs controlled by a specific address (bech32 encoding)
-         * @param {number | null} [count] The max number of results per page
-         * @param {AssetUtxosOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-         * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-         * @param {number | null} [to] Return only UTxOs created before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AssetUpdatesQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         assetUtxos: async (
             asset: string,
-            address?: string | null,
-            count?: number | null,
-            order?: AssetUtxosOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter: AssetUpdatesQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'asset' is not null or undefined
@@ -260,34 +250,9 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (address !== undefined) {
-                localVarQueryParameter.address = address;
-            }
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (order !== undefined) {
-                localVarQueryParameter.order = order;
-            }
-
-            if (from !== undefined) {
-                localVarQueryParameter.from = from;
-            }
-
-            if (to !== undefined) {
-                localVarQueryParameter.to = to;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -686,35 +651,16 @@ export const AssetsApiFp = function (configuration: Configuration) {
          * Returns references for UTxOs which contain some of the specified asset, each paired with the amount of the asset contained in the UTxO
          * @summary Native asset UTxOs
          * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-         * @param {string | null} [address] Return only UTxOs controlled by a specific address (bech32 encoding)
-         * @param {number | null} [count] The max number of results per page
-         * @param {AssetUtxosOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-         * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-         * @param {number | null} [to] Return only UTxOs created before a specific slot
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {AssetUpdatesQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async assetUtxos(
             asset: string,
-            address?: string | null,
-            count?: number | null,
-            order?: AssetUtxosOrderEnum,
-            from?: number | null,
-            to?: number | null,
-            cursor?: string | null,
+            queryParams?: AssetUtxosQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAssetUtxo>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.assetUtxos(
-                asset,
-                address,
-                count,
-                order,
-                from,
-                to,
-                cursor,
-                options,
-            );
+            const localVarAxiosArgs = await localVarAxiosParamCreator.assetUtxos(asset, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**

--- a/src/api/assets/helpers.ts
+++ b/src/api/assets/helpers.ts
@@ -31,6 +31,7 @@ import {
     PolicyAddressesQueryParams,
     PolicyInfoQueryParams,
     PolicyTxsOrderEnum,
+    PolicyTxsQueryParams,
     PolicyUtxosOrderEnum,
 } from './type';
 
@@ -397,19 +398,13 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
          * Returns a list of transactions in which a transaction input or output contains some of at least one asset of the specified minting policy ID
          * @summary Transactions moving assets of specific policy
          * @param {string} policy Hex encoded policy ID
-         * @param {number | null} [fromHeight] Return only transactions after supplied block height
-         * @param {number | null} [count] The max number of results per page
-         * @param {PolicyTxsOrderEnum} [order] The order in which the results are sorted (by block height)
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {PolicyTxsQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         policyTxs: async (
             policy: string,
-            fromHeight?: number | null,
-            count?: number | null,
-            order?: PolicyTxsOrderEnum,
-            cursor?: string | null,
+            localVarQueryParameter: PolicyTxsQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'policy' is not null or undefined
@@ -424,26 +419,9 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (fromHeight !== undefined) {
-                localVarQueryParameter.from_height = fromHeight;
-            }
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (order !== undefined) {
-                localVarQueryParameter.order = order;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -685,29 +663,16 @@ export const AssetsApiFp = function (configuration: Configuration) {
          * Returns a list of transactions in which a transaction input or output contains some of at least one asset of the specified minting policy ID
          * @summary Transactions moving assets of specific policy
          * @param {string} policy Hex encoded policy ID
-         * @param {number | null} [fromHeight] Return only transactions after supplied block height
-         * @param {number | null} [count] The max number of results per page
-         * @param {PolicyTxsOrderEnum} [order] The order in which the results are sorted (by block height)
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {PolicyTxsQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async policyTxs(
             policy: string,
-            fromHeight?: number | null,
-            count?: number | null,
-            order?: PolicyTxsOrderEnum,
-            cursor?: string | null,
+            queryParams?: PolicyTxsQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAssetTx>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.policyTxs(
-                policy,
-                fromHeight,
-                count,
-                order,
-                cursor,
-                options,
-            );
+            const localVarAxiosArgs = await localVarAxiosParamCreator.policyTxs(policy, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**

--- a/src/api/assets/helpers.ts
+++ b/src/api/assets/helpers.ts
@@ -28,6 +28,7 @@ import {
     AssetUpdatesQueryParams,
     AssetUtxosQueryParams,
     PolicyAccountsQueryParams,
+    PolicyAddressesQueryParams,
     PolicyTxsOrderEnum,
     PolicyUtxosOrderEnum,
 } from './type';
@@ -314,15 +315,13 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
          * Returns a list of addresses which hold some of an asset of the specified policy ID
          * @summary Addresses holding assets of specific policy
          * @param {string} policy Hex encoded Policy ID
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {PolicyAddressesQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         policyAddresses: async (
             policy: string,
-            count?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter: PolicyAddressesQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'policy' is not null or undefined
@@ -337,18 +336,9 @@ export const AssetsApiAxiosParamCreator = function (configuration: Configuration
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -673,18 +663,16 @@ export const AssetsApiFp = function (configuration: Configuration) {
          * Returns a list of addresses which hold some of an asset of the specified policy ID
          * @summary Addresses holding assets of specific policy
          * @param {string} policy Hex encoded Policy ID
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {PolicyAddressesQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async policyAddresses(
             policy: string,
-            count?: number | null,
-            cursor?: string | null,
+            queryParams?: PolicyAddressesQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedPolicyHolder>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.policyAddresses(policy, count, cursor, options);
+            const localVarAxiosArgs = await localVarAxiosParamCreator.policyAddresses(policy, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**

--- a/src/api/assets/index.ts
+++ b/src/api/assets/index.ts
@@ -2,6 +2,7 @@ import { AxiosRequestConfig } from 'axios';
 import { BaseAPI } from '../../base';
 import { AssetsApiFp } from './helpers';
 import {
+    AssetAccountsQueryParams,
     AssetTxsOrderEnum,
     AssetUpdatesOrderEnum,
     AssetUtxosOrderEnum,
@@ -20,15 +21,14 @@ export class AssetsApi extends BaseAPI {
      * Returns a list of accounts (as stake/reward addresses) associated with addresses which control some of the specified asset; in other words, instead of returning the addresses which hold some of the asset, the addresses are merged by their delegation part/account. Assets controlled by Byron, enterprise, or pointer addresses are omitted.  CAUTION: An asset being associated with a particular stake account does not necessarily mean the owner of that account controls the asset; use \"asset addresses\" unless you are sure you want to work with stake keys. Read more [here]( https://medium.com/adamant-security/multi-sig-concerns-mangled-addresses-and-the-dangers-of-using-stake-keys-in-your-cardano-project-94894319b1d8).
      * @summary Accounts of addresses holding specific asset
      * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-     * @param {number | null} [count] The max number of results per page
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {AssetAccountsQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetsApi
      */
-    public assetAccounts(asset: string, count?: number | null, cursor?: string | null, options?: AxiosRequestConfig) {
+    public assetAccounts(asset: string, queryParams?: AssetAccountsQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
-            .assetAccounts(asset, count, cursor, options)
+            .assetAccounts(asset, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/assets/index.ts
+++ b/src/api/assets/index.ts
@@ -3,6 +3,7 @@ import { BaseAPI } from '../../base';
 import { AssetsApiFp } from './helpers';
 import {
     AssetAccountsQueryParams,
+    AssetAddressesQueryParams,
     AssetTxsOrderEnum,
     AssetUpdatesOrderEnum,
     AssetUtxosOrderEnum,
@@ -36,15 +37,14 @@ export class AssetsApi extends BaseAPI {
      * Returns a list of addresses which control some amount of the specified asset
      * @summary Native asset addresses
      * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-     * @param {number | null} [count] The max number of results per page
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {AssetAddressesQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetsApi
      */
-    public assetAddresses(asset: string, count?: number | null, cursor?: string | null, options?: AxiosRequestConfig) {
+    public assetAddresses(asset: string, queryParams?: AssetAddressesQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
-            .assetAddresses(asset, count, cursor, options)
+            .assetAddresses(asset, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/assets/index.ts
+++ b/src/api/assets/index.ts
@@ -5,6 +5,7 @@ import {
     AssetAccountsQueryParams,
     AssetAddressesQueryParams,
     AssetTxsOrderEnum,
+    AssetTxsQueryParams,
     AssetUpdatesOrderEnum,
     AssetUtxosOrderEnum,
     PolicyTxsOrderEnum,
@@ -66,24 +67,14 @@ export class AssetsApi extends BaseAPI {
      * Returns a list of transactions in which a transaction input or output contains some of the specified asset
      * @summary Native asset transactions
      * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-     * @param {number | null} [fromHeight] Return only transactions after supplied block height
-     * @param {number | null} [count] The max number of results per page
-     * @param {AssetTxsOrderEnum} [order] The order in which the results are sorted (by block height)
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {AssetTxsQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetsApi
      */
-    public assetTxs(
-        asset: string,
-        fromHeight?: number | null,
-        count?: number | null,
-        order?: AssetTxsOrderEnum,
-        cursor?: string | null,
-        options?: AxiosRequestConfig,
-    ) {
+    public assetTxs(asset: string, queryParams?: AssetTxsQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
-            .assetTxs(asset, fromHeight, count, order, cursor, options)
+            .assetTxs(asset, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/assets/index.ts
+++ b/src/api/assets/index.ts
@@ -7,6 +7,7 @@ import {
     AssetTxsOrderEnum,
     AssetTxsQueryParams,
     AssetUpdatesOrderEnum,
+    AssetUpdatesQueryParams,
     AssetUtxosOrderEnum,
     PolicyTxsOrderEnum,
     PolicyUtxosOrderEnum,
@@ -82,22 +83,14 @@ export class AssetsApi extends BaseAPI {
      * Returns a list of transactions in which some of the specified asset was minted or burned
      * @summary Native asset updates
      * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-     * @param {number | null} [count] The max number of results per page
-     * @param {AssetUpdatesOrderEnum} [order] The order in which the results are sorted (by block height)
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {AssetUpdatesQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetsApi
      */
-    public assetUpdates(
-        asset: string,
-        count?: number | null,
-        order?: AssetUpdatesOrderEnum,
-        cursor?: string | null,
-        options?: AxiosRequestConfig,
-    ) {
+    public assetUpdates(asset: string, queryParams?: AssetUpdatesQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
-            .assetUpdates(asset, count, order, cursor, options)
+            .assetUpdates(asset, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/assets/index.ts
+++ b/src/api/assets/index.ts
@@ -9,6 +9,7 @@ import {
     AssetUpdatesOrderEnum,
     AssetUpdatesQueryParams,
     AssetUtxosOrderEnum,
+    AssetUtxosQueryParams,
     PolicyTxsOrderEnum,
     PolicyUtxosOrderEnum,
 } from './type';
@@ -98,28 +99,14 @@ export class AssetsApi extends BaseAPI {
      * Returns references for UTxOs which contain some of the specified asset, each paired with the amount of the asset contained in the UTxO
      * @summary Native asset UTxOs
      * @param {string} asset Asset, encoded as concatenation of hex of policy ID and asset name
-     * @param {string | null} [address] Return only UTxOs controlled by a specific address (bech32 encoding)
-     * @param {number | null} [count] The max number of results per page
-     * @param {AssetUtxosOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-     * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-     * @param {number | null} [to] Return only UTxOs created before a specific slot
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {AssetUtxosQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetsApi
      */
-    public assetUtxos(
-        asset: string,
-        address?: string | null,
-        count?: number | null,
-        order?: AssetUtxosOrderEnum,
-        from?: number | null,
-        to?: number | null,
-        cursor?: string | null,
-        options?: AxiosRequestConfig,
-    ) {
+    public assetUtxos(asset: string, queryParams?: AssetUtxosQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
-            .assetUtxos(asset, address, count, order, from, to, cursor, options)
+            .assetUtxos(asset, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/assets/index.ts
+++ b/src/api/assets/index.ts
@@ -10,6 +10,7 @@ import {
     AssetUpdatesQueryParams,
     AssetUtxosOrderEnum,
     AssetUtxosQueryParams,
+    PolicyAccountsQueryParams,
     PolicyTxsOrderEnum,
     PolicyUtxosOrderEnum,
 } from './type';
@@ -114,15 +115,14 @@ export class AssetsApi extends BaseAPI {
      * Returns a list of accounts (as stake/reward addresses) associated with addresses which control some of an asset of the specified policy; in other words, instead of returning the addresses which hold the assets, the addresses are merged by their delegation part/account. Assets controlled by Byron, enterprise, or pointer addresses are omitted.  CAUTION: An asset being associated with a particular stake account does not necessarily mean the owner of that account controls the asset; use \"asset addresses\" unless you are sure you want to work with stake keys. Read more [here]( https://medium.com/adamant-security/multi-sig-concerns-mangled-addresses-and-the-dangers-of-using-stake-keys-in-your-cardano-project-94894319b1d8).
      * @summary Accounts of addresses holding assets of specific policy
      * @param {string} policy Hex encoded Policy ID
-     * @param {number | null} [count] The max number of results per page
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {PolicyAccountsQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetsApi
      */
-    public policyAccounts(policy: string, count?: number | null, cursor?: string | null, options?: AxiosRequestConfig) {
+    public policyAccounts(policy: string, queryParams?: PolicyAccountsQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
-            .policyAccounts(policy, count, cursor, options)
+            .policyAccounts(policy, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/assets/index.ts
+++ b/src/api/assets/index.ts
@@ -14,6 +14,7 @@ import {
     PolicyAddressesQueryParams,
     PolicyInfoQueryParams,
     PolicyTxsOrderEnum,
+    PolicyTxsQueryParams,
     PolicyUtxosOrderEnum,
 } from './type';
 
@@ -162,24 +163,14 @@ export class AssetsApi extends BaseAPI {
      * Returns a list of transactions in which a transaction input or output contains some of at least one asset of the specified minting policy ID
      * @summary Transactions moving assets of specific policy
      * @param {string} policy Hex encoded policy ID
-     * @param {number | null} [fromHeight] Return only transactions after supplied block height
-     * @param {number | null} [count] The max number of results per page
-     * @param {PolicyTxsOrderEnum} [order] The order in which the results are sorted (by block height)
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {PolicyTxsQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetsApi
      */
-    public policyTxs(
-        policy: string,
-        fromHeight?: number | null,
-        count?: number | null,
-        order?: PolicyTxsOrderEnum,
-        cursor?: string | null,
-        options?: AxiosRequestConfig,
-    ) {
+    public policyTxs(policy: string, queryParams?: PolicyTxsQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
-            .policyTxs(policy, fromHeight, count, order, cursor, options)
+            .policyTxs(policy, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/assets/index.ts
+++ b/src/api/assets/index.ts
@@ -11,6 +11,7 @@ import {
     AssetUtxosOrderEnum,
     AssetUtxosQueryParams,
     PolicyAccountsQueryParams,
+    PolicyAddressesQueryParams,
     PolicyTxsOrderEnum,
     PolicyUtxosOrderEnum,
 } from './type';
@@ -130,20 +131,14 @@ export class AssetsApi extends BaseAPI {
      * Returns a list of addresses which hold some of an asset of the specified policy ID
      * @summary Addresses holding assets of specific policy
      * @param {string} policy Hex encoded Policy ID
-     * @param {number | null} [count] The max number of results per page
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {PolicyAddressesQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetsApi
      */
-    public policyAddresses(
-        policy: string,
-        count?: number | null,
-        cursor?: string | null,
-        options?: AxiosRequestConfig,
-    ) {
+    public policyAddresses(policy: string, queryParams?: PolicyAddressesQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
-            .policyAddresses(policy, count, cursor, options)
+            .policyAddresses(policy, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/assets/index.ts
+++ b/src/api/assets/index.ts
@@ -12,6 +12,7 @@ import {
     AssetUtxosQueryParams,
     PolicyAccountsQueryParams,
     PolicyAddressesQueryParams,
+    PolicyInfoQueryParams,
     PolicyTxsOrderEnum,
     PolicyUtxosOrderEnum,
 } from './type';
@@ -146,15 +147,14 @@ export class AssetsApi extends BaseAPI {
      * Returns information about assets of the specified minting policy ID
      * @summary Information on assets of specific policy
      * @param {string} policy Hex encoded policy ID
-     * @param {number | null} [count] The max number of results per page
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {PolicyInfoQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetsApi
      */
-    public policyInfo(policy: string, count?: number | null, cursor?: string | null, options?: AxiosRequestConfig) {
+    public policyInfo(policy: string, queryParams?: PolicyInfoQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
-            .policyInfo(policy, count, cursor, options)
+            .policyInfo(policy, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/assets/index.ts
+++ b/src/api/assets/index.ts
@@ -4,18 +4,14 @@ import { AssetsApiFp } from './helpers';
 import {
     AssetAccountsQueryParams,
     AssetAddressesQueryParams,
-    AssetTxsOrderEnum,
     AssetTxsQueryParams,
-    AssetUpdatesOrderEnum,
     AssetUpdatesQueryParams,
-    AssetUtxosOrderEnum,
     AssetUtxosQueryParams,
     PolicyAccountsQueryParams,
     PolicyAddressesQueryParams,
     PolicyInfoQueryParams,
-    PolicyTxsOrderEnum,
     PolicyTxsQueryParams,
-    PolicyUtxosOrderEnum,
+    PolicyUtxosQueryParams,
 } from './type';
 
 /**
@@ -178,26 +174,14 @@ export class AssetsApi extends BaseAPI {
      * Returns UTxO references of UTxOs which contain some of at least one asset of the specified policy ID, each paired with a list of assets of the policy contained in the UTxO and the corresponding amounts
      * @summary UTxOs containing assets of specific policy
      * @param {string} policy Hex encoded policy ID
-     * @param {number | null} [count] The max number of results per page
-     * @param {PolicyUtxosOrderEnum} [order] The order in which the results are sorted (by slot at which UTxO was produced)
-     * @param {number | null} [from] Return only UTxOs created on or after a specific slot
-     * @param {number | null} [to] Return only UTxOs created before a specific slot
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {PolicyUtxosQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetsApi
      */
-    public policyUtxos(
-        policy: string,
-        count?: number | null,
-        order?: PolicyUtxosOrderEnum,
-        from?: number | null,
-        to?: number | null,
-        cursor?: string | null,
-        options?: AxiosRequestConfig,
-    ) {
+    public policyUtxos(policy: string, queryParams?: PolicyUtxosQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
-            .policyUtxos(policy, count, order, from, to, cursor, options)
+            .policyUtxos(policy, queryParams, options)
             .then((request) => request(this.axios));
     }
 }

--- a/src/api/assets/type.ts
+++ b/src/api/assets/type.ts
@@ -206,3 +206,24 @@ export interface PolicyAccountsQueryParams {
      */
     cursor?: string | null;
 }
+
+/**
+ * Query parameters for policyAddresses.
+ * @export
+ * @interface PolicyAddressesQueryParams
+ *
+ */
+export interface PolicyAddressesQueryParams {
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof PolicyAddressesQueryParams
+     */
+    count?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof PolicyAddressesQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/assets/type.ts
+++ b/src/api/assets/type.ts
@@ -140,3 +140,48 @@ export interface AssetUpdatesQueryParams {
      */
     cursor?: string | null;
 }
+
+/**
+ * Query parameters for assetUtxos.
+ * @export
+ * @interface AssetUtxosQueryParams
+ *
+ */
+export interface AssetUtxosQueryParams {
+    /**
+     * Return only UTxOs controlled by a specific address (bech32 encoding)
+     * @type {string | null}
+     * @memberof AssetUtxosQueryParams
+     */
+    address?: string | null;
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof AssetUtxosQueryParams
+     */
+    count?: number | null;
+    /**
+     * The order in which the results are sorted (by slot at which UTxO was produced)
+     * @type {AssetUtxosOrderEnum}
+     * @memberof AssetUtxosQueryParams
+     */
+    order?: AssetUtxosOrderEnum;
+    /**
+     * Return only UTxOs created on or after a specific slot
+     * @type {number | null}
+     * @memberof AssetUtxosQueryParams
+     */
+    from?: number | null;
+    /**
+     * Return only UTxOs created before a specific slot
+     * @type {number | null}
+     * @memberof AssetUtxosQueryParams
+     */
+    to?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof AssetUtxosQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/assets/type.ts
+++ b/src/api/assets/type.ts
@@ -248,3 +248,36 @@ export interface PolicyInfoQueryParams {
      */
     cursor?: string | null;
 }
+
+/**
+ * Query parameters for policyTxs.
+ * @export
+ * @interface PolicyTxsQueryParams
+ *
+ */
+export interface PolicyTxsQueryParams {
+    /**
+     * Return only transactions after supplied block height
+     * @type {number | null}
+     * @memberof PolicyTxsQueryParams
+     */
+    fromHeight?: number | null;
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof PolicyTxsQueryParams
+     */
+    count?: number | null;
+    /**
+     * The order in which the results are sorted (by block height)
+     * @type {AssetTxsOrderEnum}
+     * @memberof PolicyTxsQueryParams
+     */
+    order?: AssetTxsOrderEnum;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof PolicyTxsQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/assets/type.ts
+++ b/src/api/assets/type.ts
@@ -38,3 +38,24 @@ export const PolicyUtxosOrderEnum = {
     Desc: 'desc',
 } as const;
 export type PolicyUtxosOrderEnum = (typeof PolicyUtxosOrderEnum)[keyof typeof PolicyUtxosOrderEnum];
+
+/**
+ * Query parameters for assetAccounts.
+ * @export
+ * @interface AssetAccountsQueryParams
+ *
+ */
+export interface AssetAccountsQueryParams {
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof AssetAccountsQueryParams
+     */
+    count?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof AssetAccountsQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/assets/type.ts
+++ b/src/api/assets/type.ts
@@ -227,3 +227,24 @@ export interface PolicyAddressesQueryParams {
      */
     cursor?: string | null;
 }
+
+/**
+ * Query parameters for policyInfo.
+ * @export
+ * @interface PolicyInfoQueryParams
+ *
+ */
+export interface PolicyInfoQueryParams {
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof PolicyInfoQueryParams
+     */
+    count?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof PolicyInfoQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/assets/type.ts
+++ b/src/api/assets/type.ts
@@ -80,3 +80,36 @@ export interface AssetAddressesQueryParams {
      */
     cursor?: string | null;
 }
+
+/**
+ * Query parameters for assetTxs.
+ * @export
+ * @interface AssetAddressesQueryParams
+ *
+ */
+export interface AssetTxsQueryParams {
+    /**
+     * Return only transactions after supplied block height
+     * @type {number | null}
+     * @memberof AssetTxsQueryParams
+     */
+    fromHeight?: number | null;
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof AssetTxsQueryParams
+     */
+    count?: number | null;
+    /**
+     * The order in which the results are sorted (by block height)
+     * @type {AssetTxsOrderEnum}
+     * @memberof AssetTxsQueryParams
+     */
+    order?: AssetTxsOrderEnum;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof AssetTxsQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/assets/type.ts
+++ b/src/api/assets/type.ts
@@ -84,7 +84,7 @@ export interface AssetAddressesQueryParams {
 /**
  * Query parameters for assetTxs.
  * @export
- * @interface AssetAddressesQueryParams
+ * @interface AssetTxsQueryParams
  *
  */
 export interface AssetTxsQueryParams {
@@ -110,6 +110,33 @@ export interface AssetTxsQueryParams {
      * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
      * @type {string | null}
      * @memberof AssetTxsQueryParams
+     */
+    cursor?: string | null;
+}
+
+/**
+ * Query parameters for assetUpdates.
+ * @export
+ * @interface AssetUpdatesQueryParams
+ *
+ */
+export interface AssetUpdatesQueryParams {
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof AssetUpdatesQueryParams
+     */
+    count?: number | null;
+    /**
+     * The order in which the results are sorted (by block height)
+     * @type {AssetUpdatesOrderEnum}
+     * @memberof AssetUpdatesQueryParams
+     */
+    order?: AssetUpdatesOrderEnum;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof AssetUpdatesQueryParams
      */
     cursor?: string | null;
 }

--- a/src/api/assets/type.ts
+++ b/src/api/assets/type.ts
@@ -59,3 +59,24 @@ export interface AssetAccountsQueryParams {
      */
     cursor?: string | null;
 }
+
+/**
+ * Query parameters for assetAddresses.
+ * @export
+ * @interface AssetAddressesQueryParams
+ *
+ */
+export interface AssetAddressesQueryParams {
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof AssetAddressesQueryParams
+     */
+    count?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof AssetAddressesQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/assets/type.ts
+++ b/src/api/assets/type.ts
@@ -185,3 +185,24 @@ export interface AssetUtxosQueryParams {
      */
     cursor?: string | null;
 }
+
+/**
+ * Query parameters for policyAccounts.
+ * @export
+ * @interface PolicyAccountsQueryParams
+ *
+ */
+export interface PolicyAccountsQueryParams {
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof PolicyAccountsQueryParams
+     */
+    count?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof PolicyAccountsQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/assets/type.ts
+++ b/src/api/assets/type.ts
@@ -270,14 +270,53 @@ export interface PolicyTxsQueryParams {
     count?: number | null;
     /**
      * The order in which the results are sorted (by block height)
-     * @type {AssetTxsOrderEnum}
+     * @type {PolicyTxsOrderEnum}
      * @memberof PolicyTxsQueryParams
      */
-    order?: AssetTxsOrderEnum;
+    order?: PolicyTxsOrderEnum;
     /**
      * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
      * @type {string | null}
      * @memberof PolicyTxsQueryParams
+     */
+    cursor?: string | null;
+}
+
+/**
+ * Query parameters for policyUtxos.
+ * @export
+ * @interface PolicyUtxosQueryParams
+ *
+ */
+export interface PolicyUtxosQueryParams {
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof PolicyUtxosQueryParams
+     */
+    count?: number | null;
+    /**
+     * The order in which the results are sorted (by slot at which UTxO was produced)
+     * @type {PolicyUtxosOrderEnum}
+     * @memberof PolicyUtxosQueryParams
+     */
+    order?: PolicyUtxosOrderEnum;
+    /**
+     * Return only UTxOs created on or after a specific slot
+     * @type {number | null}
+     * @memberof PolicyUtxosQueryParams
+     */
+    from?: number | null;
+    /**
+     * Return only UTxOs created before a specific slot
+     * @type {number | null}
+     * @memberof PolicyUtxosQueryParams
+     */
+    to?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof PolicyUtxosQueryParams
      */
     cursor?: string | null;
 }

--- a/src/api/blocks/helpers.ts
+++ b/src/api/blocks/helpers.ts
@@ -82,22 +82,22 @@ export const BlocksApiFp = function (configuration: Configuration) {
     };
 };
 
-/**
- * BlocksApi - factory interface
- * @export
- */
-export const BlocksApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = BlocksApiFp(configuration);
-    return {
-        /**
-         * Returns information about the specified block including more advanced technical properties
-         * @summary Block information
-         * @param {string} hashOrHeight Block height or hex encoded block hash
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        blockInfo(hashOrHeight: string, options?: any): AxiosPromise<TimestampedBlockInfo> {
-            return localVarFp.blockInfo(hashOrHeight, options).then((request) => request(axios, basePath));
-        },
-    };
-};
+// /**
+//  * BlocksApi - factory interface
+//  * @export
+//  */
+// export const BlocksApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
+//     const localVarFp = BlocksApiFp(configuration);
+//     return {
+//         /**
+//          * Returns information about the specified block including more advanced technical properties
+//          * @summary Block information
+//          * @param {string} hashOrHeight Block height or hex encoded block hash
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         blockInfo(hashOrHeight: string, options?: any): AxiosPromise<TimestampedBlockInfo> {
+//             return localVarFp.blockInfo(hashOrHeight, options).then((request) => request(axios, basePath));
+//         },
+//     };
+// };

--- a/src/api/datum/helpers.ts
+++ b/src/api/datum/helpers.ts
@@ -82,22 +82,22 @@ export const DatumApiFp = function (configuration: Configuration) {
     };
 };
 
-/**
- * DatumApi - factory interface
- * @export
- */
-export const DatumApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = DatumApiFp(configuration);
-    return {
-        /**
-         * Returns the datum corresponding to the specified datum hash, if the datum has been seen on-chain
-         * @summary Datum by datum hash
-         * @param {string} datumHash Hex encoded datum hash
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        lookupDatum(datumHash: string, options?: any): AxiosPromise<TimestampedDatum> {
-            return localVarFp.lookupDatum(datumHash, options).then((request) => request(axios, basePath));
-        },
-    };
-};
+// /**
+//  * DatumApi - factory interface
+//  * @export
+//  */
+// export const DatumApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
+//     const localVarFp = DatumApiFp(configuration);
+//     return {
+//         /**
+//          * Returns the datum corresponding to the specified datum hash, if the datum has been seen on-chain
+//          * @summary Datum by datum hash
+//          * @param {string} datumHash Hex encoded datum hash
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         lookupDatum(datumHash: string, options?: any): AxiosPromise<TimestampedDatum> {
+//             return localVarFp.lookupDatum(datumHash, options).then((request) => request(axios, basePath));
+//         },
+//     };
+// };

--- a/src/api/ecosystem/helpers.ts
+++ b/src/api/ecosystem/helpers.ts
@@ -82,22 +82,22 @@ export const EcosystemApiFp = function (configuration: Configuration) {
     };
 };
 
-/**
- * EcosystemApi - factory interface
- * @export
- */
-export const EcosystemApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = EcosystemApiFp(configuration);
-    return {
-        /**
-         * Returns the Cardano address corresponding to an ADA Handle
-         * @summary Resolve ADA Handle
-         * @param {string} handle Ada Handle to resolve
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        adahandleResolve(handle: string, options?: any): AxiosPromise<TimestampedAddress> {
-            return localVarFp.adahandleResolve(handle, options).then((request) => request(axios, basePath));
-        },
-    };
-};
+// /**
+//  * EcosystemApi - factory interface
+//  * @export
+//  */
+// export const EcosystemApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
+//     const localVarFp = EcosystemApiFp(configuration);
+//     return {
+//         /**
+//          * Returns the Cardano address corresponding to an ADA Handle
+//          * @summary Resolve ADA Handle
+//          * @param {string} handle Ada Handle to resolve
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         adahandleResolve(handle: string, options?: any): AxiosPromise<TimestampedAddress> {
+//             return localVarFp.adahandleResolve(handle, options).then((request) => request(axios, basePath));
+//         },
+//     };
+// };

--- a/src/api/epochs/helpers.ts
+++ b/src/api/epochs/helpers.ts
@@ -126,31 +126,31 @@ export const EpochsApiFp = function (configuration: Configuration) {
     };
 };
 
-/**
- * EpochsApi - factory interface
- * @export
- */
-export const EpochsApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = EpochsApiFp(configuration);
-    return {
-        /**
-         * Returns a summary of information about the current epoch
-         * @summary Current epoch details
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        currentEpoch(options?: any): AxiosPromise<TimestampedCurrentEpochInfo> {
-            return localVarFp.currentEpoch(options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns a summary of information about a specific epoch
-         * @summary Specific epoch details
-         * @param {number} epochNo Epoch number to return information about
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        epochInfo(epochNo: number, options?: any): AxiosPromise<TimestampedEpochInfo> {
-            return localVarFp.epochInfo(epochNo, options).then((request) => request(axios, basePath));
-        },
-    };
-};
+// /**
+//  * EpochsApi - factory interface
+//  * @export
+//  */
+// export const EpochsApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
+//     const localVarFp = EpochsApiFp(configuration);
+//     return {
+//         /**
+//          * Returns a summary of information about the current epoch
+//          * @summary Current epoch details
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         currentEpoch(options?: any): AxiosPromise<TimestampedCurrentEpochInfo> {
+//             return localVarFp.currentEpoch(options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns a summary of information about a specific epoch
+//          * @summary Specific epoch details
+//          * @param {number} epochNo Epoch number to return information about
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         epochInfo(epochNo: number, options?: any): AxiosPromise<TimestampedEpochInfo> {
+//             return localVarFp.epochInfo(epochNo, options).then((request) => request(axios, basePath));
+//         },
+//     };
+// };

--- a/src/api/general/helpers.ts
+++ b/src/api/general/helpers.ts
@@ -204,48 +204,48 @@ export const GeneralApiFp = function (configuration: Configuration) {
     };
 };
 
-/**
- * GeneralApi - factory interface
- * @export
- */
-export const GeneralApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = GeneralApiFp(configuration);
-    return {
-        /**
-         * Returns the identifier of the most recently processed block on the network
-         * @summary Chain tip
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        chainTip(options?: any): AxiosPromise<TimestampedChainTip> {
-            return localVarFp.chainTip(options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns the blockchain era history
-         * @summary Era history
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        eraHistory(options?: any): AxiosPromise<TimestampedEraSummaries> {
-            return localVarFp.eraHistory(options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns the current blockchain protocol parameters
-         * @summary Protocol parameters
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        protocolParams(options?: any): AxiosPromise<TimestampedProtocolParameters> {
-            return localVarFp.protocolParams(options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns the blockchain system start time
-         * @summary Blockchain system start
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        systemStart(options?: any): AxiosPromise<TimestampedSystemStart> {
-            return localVarFp.systemStart(options).then((request) => request(axios, basePath));
-        },
-    };
-};
+// /**
+//  * GeneralApi - factory interface
+//  * @export
+//  */
+// export const GeneralApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
+//     const localVarFp = GeneralApiFp(configuration);
+//     return {
+//         /**
+//          * Returns the identifier of the most recently processed block on the network
+//          * @summary Chain tip
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         chainTip(options?: any): AxiosPromise<TimestampedChainTip> {
+//             return localVarFp.chainTip(options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns the blockchain era history
+//          * @summary Era history
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         eraHistory(options?: any): AxiosPromise<TimestampedEraSummaries> {
+//             return localVarFp.eraHistory(options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns the current blockchain protocol parameters
+//          * @summary Protocol parameters
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         protocolParams(options?: any): AxiosPromise<TimestampedProtocolParameters> {
+//             return localVarFp.protocolParams(options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns the blockchain system start time
+//          * @summary Blockchain system start
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         systemStart(options?: any): AxiosPromise<TimestampedSystemStart> {
+//             return localVarFp.systemStart(options).then((request) => request(axios, basePath));
+//         },
+//     };
+// };

--- a/src/api/pools/helpers.ts
+++ b/src/api/pools/helpers.ts
@@ -19,7 +19,13 @@ import {
     TimestampedPoolRelays,
     TimestampedPoolUpdates,
 } from '../type';
-import { ListPoolsQueryParams, PoolBlocksOrderEnum, PoolBlocksQueryParams, PoolHistoryOrderEnum } from './type';
+import {
+    ListPoolsQueryParams,
+    PoolBlocksOrderEnum,
+    PoolBlocksQueryParams,
+    PoolDelegatorsQueryParams,
+    PoolHistoryOrderEnum,
+} from './type';
 
 /**
  * PoolsApi - axios parameter creator
@@ -108,15 +114,13 @@ export const PoolsApiAxiosParamCreator = function (configuration: Configuration)
          * Returns a list of delegators of the specified pool
          * @summary Stake pool delegators
          * @param {string} poolId Pool ID in bech32 format
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {PoolDelegatorsQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         poolDelegators: async (
             poolId: string,
-            count?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter: PoolDelegatorsQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'poolId' is not null or undefined
@@ -131,18 +135,9 @@ export const PoolsApiAxiosParamCreator = function (configuration: Configuration)
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -415,18 +410,16 @@ export const PoolsApiFp = function (configuration: Configuration) {
          * Returns a list of delegators of the specified pool
          * @summary Stake pool delegators
          * @param {string} poolId Pool ID in bech32 format
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {PoolDelegatorsQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async poolDelegators(
             poolId: string,
-            count?: number | null,
-            cursor?: string | null,
+            queryParams?: PoolDelegatorsQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedDelegatorInfo>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.poolDelegators(poolId, count, cursor, options);
+            const localVarAxiosArgs = await localVarAxiosParamCreator.poolDelegators(poolId, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**

--- a/src/api/pools/helpers.ts
+++ b/src/api/pools/helpers.ts
@@ -19,7 +19,7 @@ import {
     TimestampedPoolRelays,
     TimestampedPoolUpdates,
 } from '../type';
-import { ListPoolsQueryParams, PoolBlocksOrderEnum, PoolHistoryOrderEnum } from './type';
+import { ListPoolsQueryParams, PoolBlocksOrderEnum, PoolBlocksQueryParams, PoolHistoryOrderEnum } from './type';
 
 /**
  * PoolsApi - axios parameter creator
@@ -66,19 +66,13 @@ export const PoolsApiAxiosParamCreator = function (configuration: Configuration)
          * Return information about blocks minted by a given pool for all epochs (or just for epoch `epoch_no` if provided)
          * @summary Stake pool blocks
          * @param {string} poolId Pool ID in bech32 format
-         * @param {number | null} [epochNo] Epoch number to fetch results for
-         * @param {number | null} [count] The max number of results per page
-         * @param {PoolBlocksOrderEnum} [order] The order in which the results are sorted (by block absolute slot)
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {PoolBlocksQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         poolBlocks: async (
             poolId: string,
-            epochNo?: number | null,
-            count?: number | null,
-            order?: PoolBlocksOrderEnum,
-            cursor?: string | null,
+            localVarQueryParameter: PoolBlocksQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'poolId' is not null or undefined
@@ -93,26 +87,9 @@ export const PoolsApiAxiosParamCreator = function (configuration: Configuration)
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (epochNo !== undefined) {
-                localVarQueryParameter.epoch_no = epochNo;
-            }
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (order !== undefined) {
-                localVarQueryParameter.order = order;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -422,29 +399,16 @@ export const PoolsApiFp = function (configuration: Configuration) {
          * Return information about blocks minted by a given pool for all epochs (or just for epoch `epoch_no` if provided)
          * @summary Stake pool blocks
          * @param {string} poolId Pool ID in bech32 format
-         * @param {number | null} [epochNo] Epoch number to fetch results for
-         * @param {number | null} [count] The max number of results per page
-         * @param {PoolBlocksOrderEnum} [order] The order in which the results are sorted (by block absolute slot)
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {PoolBlocksQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async poolBlocks(
             poolId: string,
-            epochNo?: number | null,
-            count?: number | null,
-            order?: PoolBlocksOrderEnum,
-            cursor?: string | null,
+            queryParams?: PoolBlocksQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedPoolBlock>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.poolBlocks(
-                poolId,
-                epochNo,
-                count,
-                order,
-                cursor,
-                options,
-            );
+            const localVarAxiosArgs = await localVarAxiosParamCreator.poolBlocks(poolId, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**

--- a/src/api/pools/helpers.ts
+++ b/src/api/pools/helpers.ts
@@ -19,14 +19,7 @@ import {
     TimestampedPoolRelays,
     TimestampedPoolUpdates,
 } from '../type';
-import {
-    ListPoolsQueryParams,
-    PoolBlocksOrderEnum,
-    PoolBlocksQueryParams,
-    PoolDelegatorsQueryParams,
-    PoolHistoryOrderEnum,
-    PoolHistoryQueryParams,
-} from './type';
+import { ListPoolsQueryParams, PoolBlocksQueryParams, PoolDelegatorsQueryParams, PoolHistoryQueryParams } from './type';
 
 /**
  * PoolsApi - axios parameter creator

--- a/src/api/pools/helpers.ts
+++ b/src/api/pools/helpers.ts
@@ -25,6 +25,7 @@ import {
     PoolBlocksQueryParams,
     PoolDelegatorsQueryParams,
     PoolHistoryOrderEnum,
+    PoolHistoryQueryParams,
 } from './type';
 
 /**
@@ -156,19 +157,13 @@ export const PoolsApiAxiosParamCreator = function (configuration: Configuration)
          * Returns per-epoch information about the specified pool (or just for epoch `epoch_no` if provided)
          * @summary Stake pool history
          * @param {string} poolId Pool ID in bech32 format
-         * @param {number | null} [epochNo] Epoch number to fetch results for
-         * @param {number | null} [count] The max number of results per page
-         * @param {PoolHistoryOrderEnum} [order] The order in which the results are sorted (by epoch number)
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {PoolHistoryQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         poolHistory: async (
             poolId: string,
-            epochNo?: number | null,
-            count?: number | null,
-            order?: PoolHistoryOrderEnum,
-            cursor?: string | null,
+            localVarQueryParameter: PoolHistoryQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'poolId' is not null or undefined
@@ -183,26 +178,9 @@ export const PoolsApiAxiosParamCreator = function (configuration: Configuration)
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (epochNo !== undefined) {
-                localVarQueryParameter.epoch_no = epochNo;
-            }
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (order !== undefined) {
-                localVarQueryParameter.order = order;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -426,29 +404,16 @@ export const PoolsApiFp = function (configuration: Configuration) {
          * Returns per-epoch information about the specified pool (or just for epoch `epoch_no` if provided)
          * @summary Stake pool history
          * @param {string} poolId Pool ID in bech32 format
-         * @param {number | null} [epochNo] Epoch number to fetch results for
-         * @param {number | null} [count] The max number of results per page
-         * @param {PoolHistoryOrderEnum} [order] The order in which the results are sorted (by epoch number)
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param  {PoolHistoryQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async poolHistory(
             poolId: string,
-            epochNo?: number | null,
-            count?: number | null,
-            order?: PoolHistoryOrderEnum,
-            cursor?: string | null,
+            queryParams?: PoolHistoryQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedPoolHistory>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.poolHistory(
-                poolId,
-                epochNo,
-                count,
-                order,
-                cursor,
-                options,
-            );
+            const localVarAxiosArgs = await localVarAxiosParamCreator.poolHistory(poolId, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**

--- a/src/api/pools/helpers.ts
+++ b/src/api/pools/helpers.ts
@@ -19,7 +19,7 @@ import {
     TimestampedPoolRelays,
     TimestampedPoolUpdates,
 } from '../type';
-import { PoolBlocksOrderEnum, PoolHistoryOrderEnum } from './type';
+import { ListPoolsQueryParams, PoolBlocksOrderEnum, PoolHistoryOrderEnum } from './type';
 
 /**
  * PoolsApi - axios parameter creator
@@ -30,14 +30,12 @@ export const PoolsApiAxiosParamCreator = function (configuration: Configuration)
         /**
          * Returns a list of currently registered stake pools
          * @summary List registered stake pools
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {ListPoolsQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         listPools: async (
-            count?: number | null,
-            cursor?: string | null,
+            localVarQueryParameter?: ListPoolsQueryParams,
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             const localVarPath = `/pools`;
@@ -47,18 +45,9 @@ export const PoolsApiAxiosParamCreator = function (configuration: Configuration)
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (cursor !== undefined) {
-                localVarQueryParameter.cursor = cursor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -418,17 +407,15 @@ export const PoolsApiFp = function (configuration: Configuration) {
         /**
          * Returns a list of currently registered stake pools
          * @summary List registered stake pools
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+         * @param {ListPoolsQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async listPools(
-            count?: number | null,
-            cursor?: string | null,
+            queryParams?: ListPoolsQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedPoolListInfo>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.listPools(count, cursor, options);
+            const localVarAxiosArgs = await localVarAxiosParamCreator.listPools(queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**
@@ -566,128 +553,128 @@ export const PoolsApiFp = function (configuration: Configuration) {
     };
 };
 
-/**
- * PoolsApi - factory interface
- * @export
- */
-export const PoolsApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = PoolsApiFp(configuration);
-    return {
-        /**
-         * Returns a list of currently registered stake pools
-         * @summary List registered stake pools
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        listPools(count?: number | null, cursor?: string | null, options?: any): AxiosPromise<PaginatedPoolListInfo> {
-            return localVarFp.listPools(count, cursor, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Return information about blocks minted by a given pool for all epochs (or just for epoch `epoch_no` if provided)
-         * @summary Stake pool blocks
-         * @param {string} poolId Pool ID in bech32 format
-         * @param {number | null} [epochNo] Epoch number to fetch results for
-         * @param {number | null} [count] The max number of results per page
-         * @param {PoolBlocksOrderEnum} [order] The order in which the results are sorted (by block absolute slot)
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        poolBlocks(
-            poolId: string,
-            epochNo?: number | null,
-            count?: number | null,
-            order?: PoolBlocksOrderEnum,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedPoolBlock> {
-            return localVarFp
-                .poolBlocks(poolId, epochNo, count, order, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns a list of delegators of the specified pool
-         * @summary Stake pool delegators
-         * @param {string} poolId Pool ID in bech32 format
-         * @param {number | null} [count] The max number of results per page
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        poolDelegators(
-            poolId: string,
-            count?: number | null,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedDelegatorInfo> {
-            return localVarFp
-                .poolDelegators(poolId, count, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns per-epoch information about the specified pool (or just for epoch `epoch_no` if provided)
-         * @summary Stake pool history
-         * @param {string} poolId Pool ID in bech32 format
-         * @param {number | null} [epochNo] Epoch number to fetch results for
-         * @param {number | null} [count] The max number of results per page
-         * @param {PoolHistoryOrderEnum} [order] The order in which the results are sorted (by epoch number)
-         * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        poolHistory(
-            poolId: string,
-            epochNo?: number | null,
-            count?: number | null,
-            order?: PoolHistoryOrderEnum,
-            cursor?: string | null,
-            options?: any,
-        ): AxiosPromise<PaginatedPoolHistory> {
-            return localVarFp
-                .poolHistory(poolId, epochNo, count, order, cursor, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns current information about the specified pool
-         * @summary Stake pool information
-         * @param {string} poolId Pool ID in bech32 format
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        poolInfo(poolId: string, options?: any): AxiosPromise<TimestampedPoolInfo> {
-            return localVarFp.poolInfo(poolId, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns the metadata declared on-chain by the specified stake pool
-         * @summary Stake pool metadata
-         * @param {string} poolId Pool ID in bech32 format
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        poolMetadata(poolId: string, options?: any): AxiosPromise<TimestampedPoolMetadata> {
-            return localVarFp.poolMetadata(poolId, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns a list of relays declared on-chain by the specified stake pool
-         * @summary Stake pool relays
-         * @param {string} poolId Pool ID in bech32 format
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        poolRelays(poolId: string, options?: any): AxiosPromise<TimestampedPoolRelays> {
-            return localVarFp.poolRelays(poolId, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns a list of updates relating to the specified pool
-         * @summary Stake pool updates
-         * @param {string} poolId Pool ID in bech32 format
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        poolUpdates(poolId: string, options?: any): AxiosPromise<TimestampedPoolUpdates> {
-            return localVarFp.poolUpdates(poolId, options).then((request) => request(axios, basePath));
-        },
-    };
-};
+// /**
+//  * PoolsApi - factory interface
+//  * @export
+//  */
+// export const PoolsApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
+//     const localVarFp = PoolsApiFp(configuration);
+//     return {
+//         /**
+//          * Returns a list of currently registered stake pools
+//          * @summary List registered stake pools
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         listPools(count?: number | null, cursor?: string | null, options?: any): AxiosPromise<PaginatedPoolListInfo> {
+//             return localVarFp.listPools(count, cursor, options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Return information about blocks minted by a given pool for all epochs (or just for epoch `epoch_no` if provided)
+//          * @summary Stake pool blocks
+//          * @param {string} poolId Pool ID in bech32 format
+//          * @param {number | null} [epochNo] Epoch number to fetch results for
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {PoolBlocksOrderEnum} [order] The order in which the results are sorted (by block absolute slot)
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         poolBlocks(
+//             poolId: string,
+//             epochNo?: number | null,
+//             count?: number | null,
+//             order?: PoolBlocksOrderEnum,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedPoolBlock> {
+//             return localVarFp
+//                 .poolBlocks(poolId, epochNo, count, order, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns a list of delegators of the specified pool
+//          * @summary Stake pool delegators
+//          * @param {string} poolId Pool ID in bech32 format
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         poolDelegators(
+//             poolId: string,
+//             count?: number | null,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedDelegatorInfo> {
+//             return localVarFp
+//                 .poolDelegators(poolId, count, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns per-epoch information about the specified pool (or just for epoch `epoch_no` if provided)
+//          * @summary Stake pool history
+//          * @param {string} poolId Pool ID in bech32 format
+//          * @param {number | null} [epochNo] Epoch number to fetch results for
+//          * @param {number | null} [count] The max number of results per page
+//          * @param {PoolHistoryOrderEnum} [order] The order in which the results are sorted (by epoch number)
+//          * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         poolHistory(
+//             poolId: string,
+//             epochNo?: number | null,
+//             count?: number | null,
+//             order?: PoolHistoryOrderEnum,
+//             cursor?: string | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedPoolHistory> {
+//             return localVarFp
+//                 .poolHistory(poolId, epochNo, count, order, cursor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns current information about the specified pool
+//          * @summary Stake pool information
+//          * @param {string} poolId Pool ID in bech32 format
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         poolInfo(poolId: string, options?: any): AxiosPromise<TimestampedPoolInfo> {
+//             return localVarFp.poolInfo(poolId, options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns the metadata declared on-chain by the specified stake pool
+//          * @summary Stake pool metadata
+//          * @param {string} poolId Pool ID in bech32 format
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         poolMetadata(poolId: string, options?: any): AxiosPromise<TimestampedPoolMetadata> {
+//             return localVarFp.poolMetadata(poolId, options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns a list of relays declared on-chain by the specified stake pool
+//          * @summary Stake pool relays
+//          * @param {string} poolId Pool ID in bech32 format
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         poolRelays(poolId: string, options?: any): AxiosPromise<TimestampedPoolRelays> {
+//             return localVarFp.poolRelays(poolId, options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns a list of updates relating to the specified pool
+//          * @summary Stake pool updates
+//          * @param {string} poolId Pool ID in bech32 format
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         poolUpdates(poolId: string, options?: any): AxiosPromise<TimestampedPoolUpdates> {
+//             return localVarFp.poolUpdates(poolId, options).then((request) => request(axios, basePath));
+//         },
+//     };
+// };

--- a/src/api/pools/index.ts
+++ b/src/api/pools/index.ts
@@ -7,6 +7,7 @@ import {
     PoolBlocksQueryParams,
     PoolDelegatorsQueryParams,
     PoolHistoryOrderEnum,
+    PoolHistoryQueryParams,
 } from './type';
 
 /**
@@ -64,24 +65,14 @@ export class PoolsApi extends BaseAPI {
      * Returns per-epoch information about the specified pool (or just for epoch `epoch_no` if provided)
      * @summary Stake pool history
      * @param {string} poolId Pool ID in bech32 format
-     * @param {number | null} [epochNo] Epoch number to fetch results for
-     * @param {number | null} [count] The max number of results per page
-     * @param {PoolHistoryOrderEnum} [order] The order in which the results are sorted (by epoch number)
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param  {PoolHistoryQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof PoolsApi
      */
-    public poolHistory(
-        poolId: string,
-        epochNo?: number | null,
-        count?: number | null,
-        order?: PoolHistoryOrderEnum,
-        cursor?: string | null,
-        options?: AxiosRequestConfig,
-    ) {
+    public poolHistory(poolId: string, queryParams?: PoolHistoryQueryParams, options?: AxiosRequestConfig) {
         return PoolsApiFp(this.configuration)
-            .poolHistory(poolId, epochNo, count, order, cursor, options)
+            .poolHistory(poolId, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/pools/index.ts
+++ b/src/api/pools/index.ts
@@ -1,14 +1,7 @@
 import { AxiosRequestConfig } from 'axios';
 import { BaseAPI } from '../../base';
 import { PoolsApiFp } from './helpers';
-import {
-    ListPoolsQueryParams,
-    PoolBlocksOrderEnum,
-    PoolBlocksQueryParams,
-    PoolDelegatorsQueryParams,
-    PoolHistoryOrderEnum,
-    PoolHistoryQueryParams,
-} from './type';
+import { ListPoolsQueryParams, PoolBlocksQueryParams, PoolDelegatorsQueryParams, PoolHistoryQueryParams } from './type';
 
 /**
  * PoolsApi - object-oriented interface

--- a/src/api/pools/index.ts
+++ b/src/api/pools/index.ts
@@ -1,7 +1,13 @@
 import { AxiosRequestConfig } from 'axios';
 import { BaseAPI } from '../../base';
 import { PoolsApiFp } from './helpers';
-import { ListPoolsQueryParams, PoolBlocksOrderEnum, PoolBlocksQueryParams, PoolHistoryOrderEnum } from './type';
+import {
+    ListPoolsQueryParams,
+    PoolBlocksOrderEnum,
+    PoolBlocksQueryParams,
+    PoolDelegatorsQueryParams,
+    PoolHistoryOrderEnum,
+} from './type';
 
 /**
  * PoolsApi - object-oriented interface
@@ -43,15 +49,14 @@ export class PoolsApi extends BaseAPI {
      * Returns a list of delegators of the specified pool
      * @summary Stake pool delegators
      * @param {string} poolId Pool ID in bech32 format
-     * @param {number | null} [count] The max number of results per page
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {PoolDelegatorsQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof PoolsApi
      */
-    public poolDelegators(poolId: string, count?: number | null, cursor?: string | null, options?: AxiosRequestConfig) {
+    public poolDelegators(poolId: string, queryParams?: PoolDelegatorsQueryParams, options?: AxiosRequestConfig) {
         return PoolsApiFp(this.configuration)
-            .poolDelegators(poolId, count, cursor, options)
+            .poolDelegators(poolId, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/pools/index.ts
+++ b/src/api/pools/index.ts
@@ -1,7 +1,7 @@
 import { AxiosRequestConfig } from 'axios';
 import { BaseAPI } from '../../base';
 import { PoolsApiFp } from './helpers';
-import { PoolBlocksOrderEnum, PoolHistoryOrderEnum } from './type';
+import { ListPoolsQueryParams, PoolBlocksOrderEnum, PoolHistoryOrderEnum } from './type';
 
 /**
  * PoolsApi - object-oriented interface
@@ -13,15 +13,14 @@ export class PoolsApi extends BaseAPI {
     /**
      * Returns a list of currently registered stake pools
      * @summary List registered stake pools
-     * @param {number | null} [count] The max number of results per page
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {ListPoolsQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof PoolsApi
      */
-    public listPools(count?: number | null, cursor?: string | null, options?: AxiosRequestConfig) {
+    public listPools(queryParams?: ListPoolsQueryParams, options?: AxiosRequestConfig) {
         return PoolsApiFp(this.configuration)
-            .listPools(count, cursor, options)
+            .listPools(queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/pools/index.ts
+++ b/src/api/pools/index.ts
@@ -1,7 +1,7 @@
 import { AxiosRequestConfig } from 'axios';
 import { BaseAPI } from '../../base';
 import { PoolsApiFp } from './helpers';
-import { ListPoolsQueryParams, PoolBlocksOrderEnum, PoolHistoryOrderEnum } from './type';
+import { ListPoolsQueryParams, PoolBlocksOrderEnum, PoolBlocksQueryParams, PoolHistoryOrderEnum } from './type';
 
 /**
  * PoolsApi - object-oriented interface
@@ -28,24 +28,14 @@ export class PoolsApi extends BaseAPI {
      * Return information about blocks minted by a given pool for all epochs (or just for epoch `epoch_no` if provided)
      * @summary Stake pool blocks
      * @param {string} poolId Pool ID in bech32 format
-     * @param {number | null} [epochNo] Epoch number to fetch results for
-     * @param {number | null} [count] The max number of results per page
-     * @param {PoolBlocksOrderEnum} [order] The order in which the results are sorted (by block absolute slot)
-     * @param {string | null} [cursor] Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @param {PoolBlocksQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof PoolsApi
      */
-    public poolBlocks(
-        poolId: string,
-        epochNo?: number | null,
-        count?: number | null,
-        order?: PoolBlocksOrderEnum,
-        cursor?: string | null,
-        options?: AxiosRequestConfig,
-    ) {
+    public poolBlocks(poolId: string, queryParams?: PoolBlocksQueryParams, options?: AxiosRequestConfig) {
         return PoolsApiFp(this.configuration)
-            .poolBlocks(poolId, epochNo, count, order, cursor, options)
+            .poolBlocks(poolId, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/pools/type.ts
+++ b/src/api/pools/type.ts
@@ -89,3 +89,36 @@ export interface PoolDelegatorsQueryParams {
      */
     cursor?: string | null;
 }
+
+/**
+ * Query parameters for poolHistory.
+ * @export
+ * @interface PoolHistoryQueryParams
+ *
+ */
+export interface PoolHistoryQueryParams {
+    /**
+     * Epoch number to fetch results for
+     * @type {number | null}
+     * @memberof PoolHistoryQueryParams
+     */
+    epochNo?: number | null;
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof PoolHistoryQueryParams
+     */
+    count?: number | null;
+    /**
+     * The order in which the results are sorted (by block absolute slot)
+     * @type {PoolHistoryOrderEnum}
+     * @memberof PoolHistoryQueryParams
+     */
+    order?: PoolHistoryOrderEnum;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof PoolHistoryQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/pools/type.ts
+++ b/src/api/pools/type.ts
@@ -68,3 +68,24 @@ export interface PoolBlocksQueryParams {
      */
     cursor?: string | null;
 }
+
+/**
+ * Query parameters for poolDelegators.
+ * @export
+ * @interface PoolDelegatorsQueryParams
+ *
+ */
+export interface PoolDelegatorsQueryParams {
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof PoolDelegatorsQueryParams
+     */
+    count?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof PoolDelegatorsQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/pools/type.ts
+++ b/src/api/pools/type.ts
@@ -14,3 +14,24 @@ export const PoolHistoryOrderEnum = {
     Desc: 'desc',
 } as const;
 export type PoolHistoryOrderEnum = (typeof PoolHistoryOrderEnum)[keyof typeof PoolHistoryOrderEnum];
+
+/**
+ * Query parameters for listPools.
+ * @export
+ * @interface ListPoolsQueryParams
+ *
+ */
+export interface ListPoolsQueryParams {
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof ListPoolsQueryParams
+     */
+    count?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof ListPoolsQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/pools/type.ts
+++ b/src/api/pools/type.ts
@@ -35,3 +35,36 @@ export interface ListPoolsQueryParams {
      */
     cursor?: string | null;
 }
+
+/**
+ * Query parameters for poolBlocks.
+ * @export
+ * @interface PoolBlocksQueryParams
+ *
+ */
+export interface PoolBlocksQueryParams {
+    /**
+     * Epoch number to fetch results for
+     * @type {number | null}
+     * @memberof PoolBlocksQueryParams
+     */
+    epochNo?: number | null;
+    /**
+     * The max number of results per page.
+     * @type {number | null}
+     * @memberof PoolBlocksQueryParams
+     */
+    count?: number | null;
+    /**
+     * The order in which the results are sorted (by block absolute slot)
+     * @type {PoolBlocksOrderEnum}
+     * @memberof PoolBlocksQueryParams
+     */
+    order?: PoolBlocksOrderEnum;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page.
+     * @type {string | null}
+     * @memberof PoolBlocksQueryParams
+     */
+    cursor?: string | null;
+}

--- a/src/api/scripts/helpers.ts
+++ b/src/api/scripts/helpers.ts
@@ -82,22 +82,22 @@ export const ScriptsApiFp = function (configuration: Configuration) {
     };
 };
 
-/**
- * ScriptsApi - factory interface
- * @export
- */
-export const ScriptsApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = ScriptsApiFp(configuration);
-    return {
-        /**
-         * Returns the script corresponding to the specified script hash, if the script has been seen on-chain
-         * @summary Script by script hash
-         * @param {string} scriptHash Hex encoded script hash
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        scriptByHash(scriptHash: string, options?: any): AxiosPromise<TimestampedScript> {
-            return localVarFp.scriptByHash(scriptHash, options).then((request) => request(axios, basePath));
-        },
-    };
-};
+// /**
+//  * ScriptsApi - factory interface
+//  * @export
+//  */
+// export const ScriptsApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
+//     const localVarFp = ScriptsApiFp(configuration);
+//     return {
+//         /**
+//          * Returns the script corresponding to the specified script hash, if the script has been seen on-chain
+//          * @summary Script by script hash
+//          * @param {string} scriptHash Hex encoded script hash
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         scriptByHash(scriptHash: string, options?: any): AxiosPromise<TimestampedScript> {
+//             return localVarFp.scriptByHash(scriptHash, options).then((request) => request(axios, basePath));
+//         },
+//     };
+// };

--- a/src/api/transactionManager/helpers.ts
+++ b/src/api/transactionManager/helpers.ts
@@ -11,6 +11,7 @@ import {
 } from '../../common';
 import { Configuration } from '../../configuration';
 import { TxManagerState } from '../type';
+import { TxManagerHistoryQueryParams } from './type';
 
 /**
  * TransactionManagerApi - axios parameter creator
@@ -21,14 +22,12 @@ export const TransactionManagerApiAxiosParamCreator = function (configuration: C
         /**
          * Returns the history of submitted transactions
          * @summary Transactions history
-         * @param {number} [count] The max number of results per pagination page
-         * @param {number} [page] Pagination page number to show results for
+         * @param {TxManagerHistoryQueryParams} [localVarQueryParameter] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         txManagerHistory: async (
-            count?: number,
-            page?: number,
+            localVarQueryParameter: TxManagerHistoryQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             const localVarPath = `/txmanager/history`;
@@ -38,18 +37,9 @@ export const TransactionManagerApiAxiosParamCreator = function (configuration: C
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (count !== undefined) {
-                localVarQueryParameter.count = count;
-            }
-
-            if (page !== undefined) {
-                localVarQueryParameter.page = page;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -191,17 +181,15 @@ export const TransactionManagerApiFp = function (configuration: Configuration) {
         /**
          * Returns the history of submitted transactions
          * @summary Transactions history
-         * @param {number} [count] The max number of results per pagination page
-         * @param {number} [page] Pagination page number to show results for
+         * @param {TxManagerHistoryQueryParams} [queryParams] Query parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async txManagerHistory(
-            count?: number,
-            page?: number,
+            queryParams?: TxManagerHistoryQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<TxManagerState>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.txManagerHistory(count, page, options);
+            const localVarAxiosArgs = await localVarAxiosParamCreator.txManagerHistory(queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**
@@ -249,57 +237,57 @@ export const TransactionManagerApiFp = function (configuration: Configuration) {
     };
 };
 
-/**
- * TransactionManagerApi - factory interface
- * @export
- */
-export const TransactionManagerApiFactory = function (
-    configuration: Configuration,
-    basePath?: string,
-    axios?: AxiosInstance,
-) {
-    const localVarFp = TransactionManagerApiFp(configuration);
-    return {
-        /**
-         * Returns the history of submitted transactions
-         * @summary Transactions history
-         * @param {number} [count] The max number of results per pagination page
-         * @param {number} [page] Pagination page number to show results for
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        txManagerHistory(count?: number, page?: number, options?: any): AxiosPromise<Array<TxManagerState>> {
-            return localVarFp.txManagerHistory(count, page, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns the most recent state of a transaction
-         * @summary Transaction state
-         * @param {string} txHash Hex encoded transaction hash
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        txManagerState(txHash: string, options?: any): AxiosPromise<TxManagerState> {
-            return localVarFp.txManagerState(txHash, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Submit a signed and serialized transaction to the network. A transaction submited with this endpoint will be [monitored by Maestro](../Dapp%20Platform/Transaction%20Manager).
-         * @summary Submit transaction
-         * @param {string} body CBOR encoded transaction
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        txManagerSubmit(body: string, options?: any): AxiosPromise<string> {
-            return localVarFp.txManagerSubmit(body, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Submit a signed and serialized transaction to the network. A transaction submited with this endpoint will be [Turbo Submitted and Monitored by Maestro](../Dapp%20Platform/Turbo%20Transaction).
-         * @summary Turbo submit transaction
-         * @param {string} body CBOR encoded transaction
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        txManagerTurboSubmit(body: string, options?: any): AxiosPromise<string> {
-            return localVarFp.txManagerTurboSubmit(body, options).then((request) => request(axios, basePath));
-        },
-    };
-};
+// /**
+//  * TransactionManagerApi - factory interface
+//  * @export
+//  */
+// export const TransactionManagerApiFactory = function (
+//     configuration: Configuration,
+//     basePath?: string,
+//     axios?: AxiosInstance,
+// ) {
+//     const localVarFp = TransactionManagerApiFp(configuration);
+//     return {
+//         /**
+//          * Returns the history of submitted transactions
+//          * @summary Transactions history
+//          * @param {number} [count] The max number of results per pagination page
+//          * @param {number} [page] Pagination page number to show results for
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         txManagerHistory(count?: number, page?: number, options?: any): AxiosPromise<Array<TxManagerState>> {
+//             return localVarFp.txManagerHistory(count, page, options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns the most recent state of a transaction
+//          * @summary Transaction state
+//          * @param {string} txHash Hex encoded transaction hash
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         txManagerState(txHash: string, options?: any): AxiosPromise<TxManagerState> {
+//             return localVarFp.txManagerState(txHash, options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Submit a signed and serialized transaction to the network. A transaction submited with this endpoint will be [monitored by Maestro](../Dapp%20Platform/Transaction%20Manager).
+//          * @summary Submit transaction
+//          * @param {string} body CBOR encoded transaction
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         txManagerSubmit(body: string, options?: any): AxiosPromise<string> {
+//             return localVarFp.txManagerSubmit(body, options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Submit a signed and serialized transaction to the network. A transaction submited with this endpoint will be [Turbo Submitted and Monitored by Maestro](../Dapp%20Platform/Turbo%20Transaction).
+//          * @summary Turbo submit transaction
+//          * @param {string} body CBOR encoded transaction
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         txManagerTurboSubmit(body: string, options?: any): AxiosPromise<string> {
+//             return localVarFp.txManagerTurboSubmit(body, options).then((request) => request(axios, basePath));
+//         },
+//     };
+// };

--- a/src/api/transactionManager/helpers.ts
+++ b/src/api/transactionManager/helpers.ts
@@ -95,7 +95,7 @@ export const TransactionManagerApiAxiosParamCreator = function (configuration: C
         /**
          * Submit a signed and serialized transaction to the network. A transaction submited with this endpoint will be [monitored by Maestro](../Dapp%20Platform/Transaction%20Manager).
          * @summary Submit transaction
-         * @param {string} body CBOR encoded transaction
+         * @param {string | Uint8Array} body CBOR encoded transaction
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -123,7 +123,6 @@ export const TransactionManagerApiAxiosParamCreator = function (configuration: C
                 ...headersFromBaseOptions,
                 ...options.headers,
             };
-            // localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration);
             localVarRequestOptions.data = typeof body === 'string' ? Buffer.from(body, 'hex') : Buffer.from(body);
             return {
                 url: toPathString(localVarUrlObj),
@@ -133,11 +132,14 @@ export const TransactionManagerApiAxiosParamCreator = function (configuration: C
         /**
          * Submit a signed and serialized transaction to the network. A transaction submited with this endpoint will be [Turbo Submitted and Monitored by Maestro](../Dapp%20Platform/Turbo%20Transaction).
          * @summary Turbo submit transaction
-         * @param {string} body CBOR encoded transaction
+         * @param {string | Uint8Array} body CBOR encoded transaction
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        txManagerTurboSubmit: async (body: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        txManagerTurboSubmit: async (
+            body: string | Uint8Array,
+            options: AxiosRequestConfig = {},
+        ): Promise<RequestArgs> => {
             // verify required parameter 'body' is not null or undefined
             assertParamExists('txManagerTurboSubmit', 'body', body);
             const localVarPath = `/txmanager/turbosubmit`;
@@ -161,8 +163,7 @@ export const TransactionManagerApiAxiosParamCreator = function (configuration: C
                 ...headersFromBaseOptions,
                 ...options.headers,
             };
-            localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration);
-
+            localVarRequestOptions.data = typeof body === 'string' ? Buffer.from(body, 'hex') : Buffer.from(body);
             return {
                 url: toPathString(localVarUrlObj),
                 options: localVarRequestOptions,
@@ -209,7 +210,7 @@ export const TransactionManagerApiFp = function (configuration: Configuration) {
         /**
          * Submit a signed and serialized transaction to the network. A transaction submited with this endpoint will be [monitored by Maestro](../Dapp%20Platform/Transaction%20Manager).
          * @summary Submit transaction
-         * @param {string} body CBOR encoded transaction
+         * @param {string | Uint8Array} body CBOR encoded transaction
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -223,12 +224,12 @@ export const TransactionManagerApiFp = function (configuration: Configuration) {
         /**
          * Submit a signed and serialized transaction to the network. A transaction submited with this endpoint will be [Turbo Submitted and Monitored by Maestro](../Dapp%20Platform/Turbo%20Transaction).
          * @summary Turbo submit transaction
-         * @param {string} body CBOR encoded transaction
+         * @param {string | Uint8Array} body CBOR encoded transaction
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async txManagerTurboSubmit(
-            body: string,
+            body: string | Uint8Array,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.txManagerTurboSubmit(body, options);

--- a/src/api/transactionManager/helpers.ts
+++ b/src/api/transactionManager/helpers.ts
@@ -6,7 +6,6 @@ import {
     setSearchParams,
     toPathString,
     assertParamExists,
-    serializeDataIfNeeded,
     createRequestFunction,
 } from '../../common';
 import { Configuration } from '../../configuration';

--- a/src/api/transactionManager/index.ts
+++ b/src/api/transactionManager/index.ts
@@ -1,6 +1,7 @@
 import { AxiosRequestConfig } from 'axios';
 import { BaseAPI } from '../../base';
 import { TransactionManagerApiFp } from './helpers';
+import { TxManagerHistoryQueryParams } from './type';
 
 /**
  * TransactionManagerApi - object-oriented interface
@@ -12,15 +13,14 @@ export class TransactionManagerApi extends BaseAPI {
     /**
      * Returns the history of submitted transactions
      * @summary Transactions history
-     * @param {number} [count] The max number of results per pagination page
-     * @param {number} [page] Pagination page number to show results for
+     * @param {TxManagerHistoryQueryParams} [queryParams] Query parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof TransactionManagerApi
      */
-    public txManagerHistory(count?: number, page?: number, options?: AxiosRequestConfig) {
+    public txManagerHistory(queryParams?: TxManagerHistoryQueryParams, options?: AxiosRequestConfig) {
         return TransactionManagerApiFp(this.configuration)
-            .txManagerHistory(count, page, options)
+            .txManagerHistory(queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/transactionManager/index.ts
+++ b/src/api/transactionManager/index.ts
@@ -41,7 +41,7 @@ export class TransactionManagerApi extends BaseAPI {
     /**
      * Submit a signed and serialized transaction to the network. A transaction submited with this endpoint will be [monitored by Maestro](../Dapp%20Platform/Transaction%20Manager).
      * @summary Submit transaction
-     * @param {string} body CBOR encoded transaction
+     * @param {string | Uint8Array} body CBOR encoded transaction
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof TransactionManagerApi
@@ -55,12 +55,12 @@ export class TransactionManagerApi extends BaseAPI {
     /**
      * Submit a signed and serialized transaction to the network. A transaction submited with this endpoint will be [Turbo Submitted and Monitored by Maestro](../Dapp%20Platform/Turbo%20Transaction).
      * @summary Turbo submit transaction
-     * @param {string} body CBOR encoded transaction
+     * @param {string | Uint8Array} body CBOR encoded transaction
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof TransactionManagerApi
      */
-    public txManagerTurboSubmit(body: string, options?: AxiosRequestConfig) {
+    public txManagerTurboSubmit(body: string | Uint8Array, options?: AxiosRequestConfig) {
         return TransactionManagerApiFp(this.configuration)
             .txManagerTurboSubmit(body, options)
             .then((request) => request(this.axios));

--- a/src/api/transactionManager/type.ts
+++ b/src/api/transactionManager/type.ts
@@ -1,0 +1,22 @@
+/**
+ * Query parameters for txManagerHistory.
+ * @export
+ * @interface TxManagerHistoryQueryParams
+ *
+ */
+export interface TxManagerHistoryQueryParams {
+    // * @param {number} [count]
+    // * @param {number} [page]
+    /**
+     * The max number of results per pagination page
+     * @type {number | null}
+     * @memberof TxManagerHistoryQueryParams
+     */
+    count?: number | null;
+    /**
+     * Pagination page number to show results for
+     * @type {string | null}
+     * @memberof TxManagerHistoryQueryParams
+     */
+    page?: string | null;
+}

--- a/src/api/transactions/helpers.ts
+++ b/src/api/transactions/helpers.ts
@@ -17,6 +17,7 @@ import {
     TimestampedUtxo,
     PaginatedUtxoWithBytes,
 } from '../type';
+import { TxoByTxoRefQueryParams } from './type';
 
 /**
  * TransactionsApi - axios parameter creator
@@ -145,14 +146,14 @@ export const TransactionsApiAxiosParamCreator = function (configuration: Configu
          * @summary Transaction output by output reference
          * @param {string} txHash Transaction Hash
          * @param {number} index Output Index
-         * @param {boolean | null} [withCbor] Include the CBOR encoding of the transaction output in the response
+         * @param {TxoByTxoRefQueryParams} [localVarQueryParameter] Query Parameters
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         txoByTxoRef: async (
             txHash: string,
             index: number,
-            withCbor?: boolean | null,
+            localVarQueryParameter: TxoByTxoRefQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'txHash' is not null or undefined
@@ -168,14 +169,9 @@ export const TransactionsApiAxiosParamCreator = function (configuration: Configu
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (withCbor !== undefined) {
-                localVarQueryParameter.with_cbor = withCbor;
-            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -302,17 +298,17 @@ export const TransactionsApiFp = function (configuration: Configuration) {
          * @summary Transaction output by output reference
          * @param {string} txHash Transaction Hash
          * @param {number} index Output Index
-         * @param {boolean | null} [withCbor] Include the CBOR encoding of the transaction output in the response
+         * @param {TxoByTxoRefQueryParams} [queryParams] Query Parameters
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async txoByTxoRef(
             txHash: string,
             index: number,
-            withCbor?: boolean | null,
+            queryParams?: TxoByTxoRefQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedUtxo>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.txoByTxoRef(txHash, index, withCbor, options);
+            const localVarAxiosArgs = await localVarAxiosParamCreator.txoByTxoRef(txHash, index, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
         /**
@@ -341,83 +337,83 @@ export const TransactionsApiFp = function (configuration: Configuration) {
     };
 };
 
-/**
- * TransactionsApi - factory interface
- * @export
- */
-export const TransactionsApiFactory = function (
-    configuration: Configuration,
-    basePath?: string,
-    axios?: AxiosInstance,
-) {
-    const localVarFp = TransactionsApiFp(configuration);
-    return {
-        /**
-         * Returns the address which was specified in the given transaction output.  Note that if the transaction is invalid this will only return a result for the collateral return output, should one be present in the transaction. If the transaction is valid it will not return a result for the collateral return output.
-         * @summary Address by transaction output reference
-         * @param {string} txHash Transaction Hash
-         * @param {number} index Output Index
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        addressByTxo(txHash: string, index: number, options?: any): AxiosPromise<TimestampedAddress> {
-            return localVarFp.addressByTxo(txHash, index, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns hex-encoded CBOR bytes of a transaction
-         * @summary CBOR bytes of a transaction
-         * @param {string} txHash Transaction Hash
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        txCborByTxHash(txHash: string, options?: any): AxiosPromise<TimestampedTxCbor> {
-            return localVarFp.txCborByTxHash(txHash, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns detailed information about a transaction
-         * @summary Transaction details
-         * @param {string} txHash Transaction hash in hex
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        txInfo(txHash: string, options?: any): AxiosPromise<TimestampedTransactionInfo> {
-            return localVarFp.txInfo(txHash, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns the specified transaction output.
-         * @summary Transaction output by output reference
-         * @param {string} txHash Transaction Hash
-         * @param {number} index Output Index
-         * @param {boolean | null} [withCbor] Include the CBOR encoding of the transaction output in the response
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        txoByTxoRef(
-            txHash: string,
-            index: number,
-            withCbor?: boolean | null,
-            options?: any,
-        ): AxiosPromise<TimestampedUtxo> {
-            return localVarFp.txoByTxoRef(txHash, index, withCbor, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Returns the specified transaction outputs
-         * @summary Transaction outputs by output references
-         * @param {Array<string>} requestBody
-         * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
-         * @param {boolean | null} [withCbor] Include the CBOR encoding of the transaction output in the response
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        txosByTxoRefs(
-            requestBody: Array<string>,
-            resolveDatums?: boolean | null,
-            withCbor?: boolean | null,
-            options?: any,
-        ): AxiosPromise<PaginatedUtxoWithBytes> {
-            return localVarFp
-                .txosByTxoRefs(requestBody, resolveDatums, withCbor, options)
-                .then((request) => request(axios, basePath));
-        },
-    };
-};
+// /**
+//  * TransactionsApi - factory interface
+//  * @export
+//  */
+// export const TransactionsApiFactory = function (
+//     configuration: Configuration,
+//     basePath?: string,
+//     axios?: AxiosInstance,
+// ) {
+//     const localVarFp = TransactionsApiFp(configuration);
+//     return {
+//         /**
+//          * Returns the address which was specified in the given transaction output.  Note that if the transaction is invalid this will only return a result for the collateral return output, should one be present in the transaction. If the transaction is valid it will not return a result for the collateral return output.
+//          * @summary Address by transaction output reference
+//          * @param {string} txHash Transaction Hash
+//          * @param {number} index Output Index
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         addressByTxo(txHash: string, index: number, options?: any): AxiosPromise<TimestampedAddress> {
+//             return localVarFp.addressByTxo(txHash, index, options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns hex-encoded CBOR bytes of a transaction
+//          * @summary CBOR bytes of a transaction
+//          * @param {string} txHash Transaction Hash
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         txCborByTxHash(txHash: string, options?: any): AxiosPromise<TimestampedTxCbor> {
+//             return localVarFp.txCborByTxHash(txHash, options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns detailed information about a transaction
+//          * @summary Transaction details
+//          * @param {string} txHash Transaction hash in hex
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         txInfo(txHash: string, options?: any): AxiosPromise<TimestampedTransactionInfo> {
+//             return localVarFp.txInfo(txHash, options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns the specified transaction output.
+//          * @summary Transaction output by output reference
+//          * @param {string} txHash Transaction Hash
+//          * @param {number} index Output Index
+//          * @param {boolean | null} [withCbor] Include the CBOR encoding of the transaction output in the response
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         txoByTxoRef(
+//             txHash: string,
+//             index: number,
+//             withCbor?: boolean | null,
+//             options?: any,
+//         ): AxiosPromise<TimestampedUtxo> {
+//             return localVarFp.txoByTxoRef(txHash, index, withCbor, options).then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Returns the specified transaction outputs
+//          * @summary Transaction outputs by output references
+//          * @param {Array<string>} requestBody
+//          * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
+//          * @param {boolean | null} [withCbor] Include the CBOR encoding of the transaction output in the response
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         txosByTxoRefs(
+//             requestBody: Array<string>,
+//             resolveDatums?: boolean | null,
+//             withCbor?: boolean | null,
+//             options?: any,
+//         ): AxiosPromise<PaginatedUtxoWithBytes> {
+//             return localVarFp
+//                 .txosByTxoRefs(requestBody, resolveDatums, withCbor, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//     };
+// };

--- a/src/api/transactions/helpers.ts
+++ b/src/api/transactions/helpers.ts
@@ -17,7 +17,7 @@ import {
     TimestampedUtxo,
     PaginatedUtxoWithBytes,
 } from '../type';
-import { TxoByTxoRefQueryParams } from './type';
+import { TxoByTxoRefQueryParams, TxosByTxoRefsQueryParams } from './type';
 
 /**
  * TransactionsApi - axios parameter creator
@@ -190,15 +190,13 @@ export const TransactionsApiAxiosParamCreator = function (configuration: Configu
          * Returns the specified transaction outputs
          * @summary Transaction outputs by output references
          * @param {Array<string>} requestBody
-         * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
-         * @param {boolean | null} [withCbor] Include the CBOR encoding of the transaction output in the response
+         * @param {TxosByTxoRefsQueryParams} [localVarQueryParameter] Query Parameters
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         txosByTxoRefs: async (
             requestBody: Array<string>,
-            resolveDatums?: boolean | null,
-            withCbor?: boolean | null,
+            localVarQueryParameter: TxosByTxoRefsQueryParams = {},
             options: AxiosRequestConfig = {},
         ): Promise<RequestArgs> => {
             // verify required parameter 'requestBody' is not null or undefined
@@ -210,18 +208,9 @@ export const TransactionsApiAxiosParamCreator = function (configuration: Configu
 
             const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
 
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
-
-            if (resolveDatums !== undefined) {
-                localVarQueryParameter.resolve_datums = resolveDatums;
-            }
-
-            if (withCbor !== undefined) {
-                localVarQueryParameter.with_cbor = withCbor;
-            }
 
             localVarHeaderParameter['Content-Type'] = 'application/json';
 
@@ -315,23 +304,16 @@ export const TransactionsApiFp = function (configuration: Configuration) {
          * Returns the specified transaction outputs
          * @summary Transaction outputs by output references
          * @param {Array<string>} requestBody
-         * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
-         * @param {boolean | null} [withCbor] Include the CBOR encoding of the transaction output in the response
+         * @param {TxosByTxoRefsQueryParams} [queryParams] Query Parameters
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async txosByTxoRefs(
             requestBody: Array<string>,
-            resolveDatums?: boolean | null,
-            withCbor?: boolean | null,
+            queryParams?: TxosByTxoRefsQueryParams,
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedUtxoWithBytes>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.txosByTxoRefs(
-                requestBody,
-                resolveDatums,
-                withCbor,
-                options,
-            );
+            const localVarAxiosArgs = await localVarAxiosParamCreator.txosByTxoRefs(requestBody, queryParams, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
         },
     };

--- a/src/api/transactions/index.ts
+++ b/src/api/transactions/index.ts
@@ -1,6 +1,7 @@
 import { AxiosRequestConfig } from 'axios';
 import { BaseAPI } from '../../base';
 import { TransactionsApiFp } from './helpers';
+import { TxoByTxoRefQueryParams } from './type';
 
 /**
  * TransactionsApi - object-oriented interface
@@ -57,14 +58,19 @@ export class TransactionsApi extends BaseAPI {
      * @summary Transaction output by output reference
      * @param {string} txHash Transaction Hash
      * @param {number} index Output Index
-     * @param {boolean | null} [withCbor] Include the CBOR encoding of the transaction output in the response
+     * @param {TxoByTxoRefQueryParams} [queryParams] Query Parameters
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof TransactionsApi
      */
-    public txoByTxoRef(txHash: string, index: number, withCbor?: boolean | null, options?: AxiosRequestConfig) {
+    public txoByTxoRef(
+        txHash: string,
+        index: number,
+        queryParams?: TxoByTxoRefQueryParams,
+        options?: AxiosRequestConfig,
+    ) {
         return TransactionsApiFp(this.configuration)
-            .txoByTxoRef(txHash, index, withCbor, options)
+            .txoByTxoRef(txHash, index, queryParams, options)
             .then((request) => request(this.axios));
     }
 

--- a/src/api/transactions/index.ts
+++ b/src/api/transactions/index.ts
@@ -78,20 +78,18 @@ export class TransactionsApi extends BaseAPI {
      * Returns the specified transaction outputs
      * @summary Transaction outputs by output references
      * @param {Array<string>} requestBody
-     * @param {boolean | null} [resolveDatums] Try find and include the corresponding datums for datum hashes
-     * @param {boolean | null} [withCbor] Include the CBOR encoding of the transaction output in the response
+     * @param {TxosByTxoRefsQueryParams} [queryParams] Query Parameters
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof TransactionsApi
      */
     public txosByTxoRefs(
         requestBody: Array<string>,
-        resolveDatums?: boolean | null,
-        withCbor?: boolean | null,
+        queryParams?: TxoByTxoRefQueryParams,
         options?: AxiosRequestConfig,
     ) {
         return TransactionsApiFp(this.configuration)
-            .txosByTxoRefs(requestBody, resolveDatums, withCbor, options)
+            .txosByTxoRefs(requestBody, queryParams, options)
             .then((request) => request(this.axios));
     }
 }

--- a/src/api/transactions/type.ts
+++ b/src/api/transactions/type.ts
@@ -1,0 +1,15 @@
+/**
+ * Query parameters for txoByTxoRef.
+ * @export
+ * @interface TxoByTxoRefQueryParams
+ *
+ */
+export interface TxoByTxoRefQueryParams {
+    // * @param {boolean | null} [withCbor] Include the CBOR encoding of the transaction output in the response
+    /**
+     * Include the CBOR encoding of the transaction output in the response
+     * @type {boolean | null}
+     * @memberof TxoByTxoRefQueryParams
+     */
+    withCbor?: boolean | null;
+}

--- a/src/api/transactions/type.ts
+++ b/src/api/transactions/type.ts
@@ -5,11 +5,31 @@
  *
  */
 export interface TxoByTxoRefQueryParams {
-    // * @param {boolean | null} [withCbor] Include the CBOR encoding of the transaction output in the response
     /**
      * Include the CBOR encoding of the transaction output in the response
      * @type {boolean | null}
      * @memberof TxoByTxoRefQueryParams
+     */
+    withCbor?: boolean | null;
+}
+
+/**
+ * Query parameters for txosByTxoRefs.
+ * @export
+ * @interface TxosByTxoRefsQueryParams
+ *
+ */
+export interface TxosByTxoRefsQueryParams {
+    /**
+     * Try find and include the corresponding datums for datum hashes
+     * @type {boolean | null}
+     * @memberof TxosByTxoRefsQueryParams
+     */
+    resolveDatums?: boolean | null;
+    /**
+     * Include the CBOR encoding of the transaction output in the response
+     * @type {boolean | null}
+     * @memberof TxosByTxoRefsQueryParams
      */
     withCbor?: boolean | null;
 }

--- a/src/api/vesting/helpers.ts
+++ b/src/api/vesting/helpers.ts
@@ -213,54 +213,54 @@ export const VestingApiFp = function (configuration: Configuration) {
     };
 };
 
-/**
- * VestingApi - factory interface
- * @export
- */
-export const VestingApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = VestingApiFp(configuration);
-    return {
-        /**
-         * Collect assets from the vesting contract
-         * @summary Collect assets
-         * @param {string} beneficiary Beneficiary\&#39;s bech32 address
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        contractsVestingCollectBeneficiaryPost(
-            beneficiary: string,
-            options?: any,
-        ): AxiosPromise<ContractsVestingLockPost200Response> {
-            return localVarFp
-                .contractsVestingCollectBeneficiaryPost(beneficiary, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Lock assets into the vesting contract
-         * @summary Lock assets
-         * @param {ContractsVestingLockPostRequest} contractsVestingLockPostRequest
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        contractsVestingLockPost(
-            contractsVestingLockPostRequest: ContractsVestingLockPostRequest,
-            options?: any,
-        ): AxiosPromise<ContractsVestingLockPost200Response> {
-            return localVarFp
-                .contractsVestingLockPost(contractsVestingLockPostRequest, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Detailed list of vesting assets at a beneficiary address
-         * @summary State of vesting assets
-         * @param {string} beneficiary Beneficiary bech32 address
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        contractsVestingStateBeneficiaryGet(beneficiary: string, options?: any): AxiosPromise<VestingState> {
-            return localVarFp
-                .contractsVestingStateBeneficiaryGet(beneficiary, options)
-                .then((request) => request(axios, basePath));
-        },
-    };
-};
+// /**
+//  * VestingApi - factory interface
+//  * @export
+//  */
+// export const VestingApiFactory = function (configuration: Configuration, basePath?: string, axios?: AxiosInstance) {
+//     const localVarFp = VestingApiFp(configuration);
+//     return {
+//         /**
+//          * Collect assets from the vesting contract
+//          * @summary Collect assets
+//          * @param {string} beneficiary Beneficiary\&#39;s bech32 address
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         contractsVestingCollectBeneficiaryPost(
+//             beneficiary: string,
+//             options?: any,
+//         ): AxiosPromise<ContractsVestingLockPost200Response> {
+//             return localVarFp
+//                 .contractsVestingCollectBeneficiaryPost(beneficiary, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Lock assets into the vesting contract
+//          * @summary Lock assets
+//          * @param {ContractsVestingLockPostRequest} contractsVestingLockPostRequest
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         contractsVestingLockPost(
+//             contractsVestingLockPostRequest: ContractsVestingLockPostRequest,
+//             options?: any,
+//         ): AxiosPromise<ContractsVestingLockPost200Response> {
+//             return localVarFp
+//                 .contractsVestingLockPost(contractsVestingLockPostRequest, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//         /**
+//          * Detailed list of vesting assets at a beneficiary address
+//          * @summary State of vesting assets
+//          * @param {string} beneficiary Beneficiary bech32 address
+//          * @param {*} [options] Override http request option.
+//          * @throws {RequiredError}
+//          */
+//         contractsVestingStateBeneficiaryGet(beneficiary: string, options?: any): AxiosPromise<VestingState> {
+//             return localVarFp
+//                 .contractsVestingStateBeneficiaryGet(beneficiary, options)
+//                 .then((request) => request(axios, basePath));
+//         },
+//     };
+// };


### PR DESCRIPTION
## Summary

This PR reflects the implementation of issue #18. With 2 more fixes accompanied:
1. Also include Tx submission standard for TxTurbo, with inline documentation added back
2. Added `asset` interface support for 2 apis in `addresses`.

## Type of Change

Please mark the relevant option(s) for your pull request:

- [ X ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Additional Information

Seems from the application logic all of the factory interfaces are not used (Issue #10). This refactoring hence does not cover those code and I commented out all of them. Please check if that is really redundant and remove the code.

