### PR TITLE
Feat: Moved axios instance into Configuration and using it as single source of truth

### DIFF
--- a/src/api/accounts/helpers.ts
+++ b/src/api/accounts/helpers.ts
@@ -1,4 +1,4 @@
-import globalAxios, { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
+import { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
 import { RequestArgs } from '../../base';
 import {
     assertParamExists,
@@ -420,7 +420,7 @@ export const AccountsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAddress>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.accountAddresses(stakeAddr, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns a list of native assets which are owned by addresses with the specified stake key
@@ -436,7 +436,7 @@ export const AccountsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAsset>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.accountAssets(stakeAddr, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns per-epoch history for the specified stake key
@@ -452,7 +452,7 @@ export const AccountsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAccountHistory>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.accountHistory(stakeAddr, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns various information regarding a stake account
@@ -466,7 +466,7 @@ export const AccountsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedAccountInfo>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.accountInfo(stakeAddr, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns a list of staking-related rewards for the specified stake key (pool `member` or `leader` rewards, deposit `refund`)
@@ -482,7 +482,7 @@ export const AccountsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAccountReward>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.accountRewards(stakeAddr, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns a list of updates relating to the specified stake key ( `registration`, `deregistration`, `delegation`, `withdrawal`)
@@ -498,7 +498,7 @@ export const AccountsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAccountUpdate>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.accountUpdates(stakeAddr, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
     };
 };

--- a/src/api/accounts/index.ts
+++ b/src/api/accounts/index.ts
@@ -32,7 +32,7 @@ export class AccountsApi extends BaseAPI {
     ) {
         return AccountsApiFp(this.configuration)
             .accountAddresses(stakeAddr, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -47,7 +47,7 @@ export class AccountsApi extends BaseAPI {
     public accountAssets(stakeAddr: string, queryParams?: AccountAssetsQueryParams, options?: AxiosRequestConfig) {
         return AccountsApiFp(this.configuration)
             .accountAssets(stakeAddr, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -62,7 +62,7 @@ export class AccountsApi extends BaseAPI {
     public accountHistory(stakeAddr: string, queryParams?: AccountHistoryQueryParams, options?: AxiosRequestConfig) {
         return AccountsApiFp(this.configuration)
             .accountHistory(stakeAddr, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -76,7 +76,7 @@ export class AccountsApi extends BaseAPI {
     public accountInfo(stakeAddr: string, options?: AxiosRequestConfig) {
         return AccountsApiFp(this.configuration)
             .accountInfo(stakeAddr, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -91,7 +91,7 @@ export class AccountsApi extends BaseAPI {
     public accountRewards(stakeAddr: string, queryParams?: AccountRewardsQueryParams, options?: AxiosRequestConfig) {
         return AccountsApiFp(this.configuration)
             .accountRewards(stakeAddr, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -106,7 +106,7 @@ export class AccountsApi extends BaseAPI {
     public accountUpdates(stakeAddr: string, queryParams?: AccountUpdatesQueryParams, options?: AxiosRequestConfig) {
         return AccountsApiFp(this.configuration)
             .accountUpdates(stakeAddr, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 }
 

--- a/src/api/addresses/helpers.ts
+++ b/src/api/addresses/helpers.ts
@@ -1,4 +1,4 @@
-import globalAxios, { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
+import { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
 import { RequestArgs } from '../../base';
 import {
     assertParamExists,
@@ -383,7 +383,7 @@ export const AddressesApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AddressInfo>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.decodeAddress(address, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns the number of transactions in which the address spent or received some funds.  Specifically, the number of transactions where: the address controlled at least one of the transaction inputs and/or receives one of the outputs AND the transaction is phase-2 valid, OR, the address controlled at least one of the collateral inputs and/or receives the collateral return output AND the transaction is phase-2 invalid. [Read more](https://docs.cardano.org/plutus/collateral-mechanism/).
@@ -397,7 +397,7 @@ export const AddressesApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedTxCount>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.txCountByAddress(address, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns transactions in which the specified address spent or received funds.  Specifically, the transactions where: the address controlled at least one of the transaction inputs and/or receives one of the outputs AND the transaction is phase-2 valid, OR, the address controlled at least one of the collateral inputs and/or receives the collateral return output AND the transaction is phase-2 invalid. [Read more](https://docs.cardano.org/plutus/collateral-mechanism/).
@@ -413,7 +413,7 @@ export const AddressesApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAddressTransaction>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.txsByAddress(address, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns transactions in which the specified payment credential spent or received funds.  Specifically, the transactions where: the payment credential was used in an address which controlled at least one of the transaction inputs and/or receives one of the outputs AND the transaction is phase-2 valid, OR, the address controlled at least one of the collateral inputs and/or receives the collateral return output AND the transaction is phase-2 invalid. [Read more](https://docs.cardano.org/plutus/collateral-mechanism/).
@@ -433,7 +433,7 @@ export const AddressesApiFp = function (configuration: Configuration) {
                 queryParams,
                 options,
             );
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns references (pair of transaction hash and output index in transaction) for UTxOs controlled by the specified address
@@ -449,7 +449,7 @@ export const AddressesApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedUtxoRef>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.utxoRefsAtAddress(address, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Return detailed information on UTxOs controlled by an address
@@ -465,7 +465,7 @@ export const AddressesApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedUtxoWithSlot>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.utxosByAddress(address, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Return detailed information on UTxOs which are controlled by some address in the specified list of addresses
@@ -485,7 +485,7 @@ export const AddressesApiFp = function (configuration: Configuration) {
                 queryParams,
                 options,
             );
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Return detailed information on UTxOs controlled by addresses which use the specified payment credential
@@ -505,7 +505,7 @@ export const AddressesApiFp = function (configuration: Configuration) {
                 queryParams,
                 options,
             );
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
     };
 };

--- a/src/api/addresses/index.ts
+++ b/src/api/addresses/index.ts
@@ -27,7 +27,7 @@ export class AddressesApi extends BaseAPI {
     public decodeAddress(address: string, options?: AxiosRequestConfig) {
         return AddressesApiFp(this.configuration)
             .decodeAddress(address, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -41,7 +41,7 @@ export class AddressesApi extends BaseAPI {
     public txCountByAddress(address: string, options?: AxiosRequestConfig) {
         return AddressesApiFp(this.configuration)
             .txCountByAddress(address, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -56,7 +56,7 @@ export class AddressesApi extends BaseAPI {
     public txsByAddress(address: string, queryParams?: TxsByAddressQueryParams, options?: AxiosRequestConfig) {
         return AddressesApiFp(this.configuration)
             .txsByAddress(address, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -75,7 +75,7 @@ export class AddressesApi extends BaseAPI {
     ) {
         return AddressesApiFp(this.configuration)
             .txsByPaymentCred(credential, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -90,7 +90,7 @@ export class AddressesApi extends BaseAPI {
     public utxoRefsAtAddress(address: string, queryParams?: TxsByPaymentCredQueryParams, options?: AxiosRequestConfig) {
         return AddressesApiFp(this.configuration)
             .utxoRefsAtAddress(address, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -105,7 +105,7 @@ export class AddressesApi extends BaseAPI {
     public utxosByAddress(address: string, queryParams?: UtxosByAddressQueryParams, options?: AxiosRequestConfig) {
         return AddressesApiFp(this.configuration)
             .utxosByAddress(address, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -124,7 +124,7 @@ export class AddressesApi extends BaseAPI {
     ) {
         return AddressesApiFp(this.configuration)
             .utxosByAddresses(requestBody, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -143,7 +143,7 @@ export class AddressesApi extends BaseAPI {
     ) {
         return AddressesApiFp(this.configuration)
             .utxosByPaymentCred(credential, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 }
 

--- a/src/api/assets/helpers.ts
+++ b/src/api/assets/helpers.ts
@@ -1,4 +1,4 @@
-import globalAxios, { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
+import { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
 import { RequestArgs } from '../../base';
 import {
     assertParamExists,
@@ -501,7 +501,7 @@ export const AssetsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAssetHolderAccount>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.assetAccounts(asset, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns a list of addresses which control some amount of the specified asset
@@ -517,7 +517,7 @@ export const AssetsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAssetHolder>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.assetAddresses(asset, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Return a summary of information about an asset
@@ -531,7 +531,7 @@ export const AssetsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedAssetInfo>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.assetInfo(asset, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns a list of transactions in which a transaction input or output contains some of the specified asset
@@ -547,7 +547,7 @@ export const AssetsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAssetTx>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.assetTxs(asset, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns a list of transactions in which some of the specified asset was minted or burned
@@ -563,7 +563,7 @@ export const AssetsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedMintingTx>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.assetUpdates(asset, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns references for UTxOs which contain some of the specified asset, each paired with the amount of the asset contained in the UTxO
@@ -579,7 +579,7 @@ export const AssetsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAssetUtxo>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.assetUtxos(asset, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns a list of accounts (as stake/reward addresses) associated with addresses which control some of an asset of the specified policy; in other words, instead of returning the addresses which hold the assets, the addresses are merged by their delegation part/account. Assets controlled by Byron, enterprise, or pointer addresses are omitted.  CAUTION: An asset being associated with a particular stake account does not necessarily mean the owner of that account controls the asset; use \"asset addresses\" unless you are sure you want to work with stake keys. Read more [here]( https://medium.com/adamant-security/multi-sig-concerns-mangled-addresses-and-the-dangers-of-using-stake-keys-in-your-cardano-project-94894319b1d8).
@@ -595,7 +595,7 @@ export const AssetsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedPolicyHolderAccount>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.policyAccounts(policy, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns a list of addresses which hold some of an asset of the specified policy ID
@@ -611,7 +611,7 @@ export const AssetsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedPolicyHolder>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.policyAddresses(policy, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns information about assets of the specified minting policy ID
@@ -627,7 +627,7 @@ export const AssetsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAssetInfo>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.policyInfo(policy, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns a list of transactions in which a transaction input or output contains some of at least one asset of the specified minting policy ID
@@ -643,7 +643,7 @@ export const AssetsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedAssetTx>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.policyTxs(policy, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns UTxO references of UTxOs which contain some of at least one asset of the specified policy ID, each paired with a list of assets of the policy contained in the UTxO and the corresponding amounts
@@ -659,7 +659,7 @@ export const AssetsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedPolicyUtxo>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.policyUtxos(policy, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
     };
 };

--- a/src/api/assets/index.ts
+++ b/src/api/assets/index.ts
@@ -33,7 +33,7 @@ export class AssetsApi extends BaseAPI {
     public assetAccounts(asset: string, queryParams?: AssetAccountsQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
             .assetAccounts(asset, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -48,7 +48,7 @@ export class AssetsApi extends BaseAPI {
     public assetAddresses(asset: string, queryParams?: AssetAddressesQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
             .assetAddresses(asset, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -62,7 +62,7 @@ export class AssetsApi extends BaseAPI {
     public assetInfo(asset: string, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
             .assetInfo(asset, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -77,7 +77,7 @@ export class AssetsApi extends BaseAPI {
     public assetTxs(asset: string, queryParams?: AssetTxsQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
             .assetTxs(asset, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -92,7 +92,7 @@ export class AssetsApi extends BaseAPI {
     public assetUpdates(asset: string, queryParams?: AssetUpdatesQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
             .assetUpdates(asset, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -107,7 +107,7 @@ export class AssetsApi extends BaseAPI {
     public assetUtxos(asset: string, queryParams?: AssetUtxosQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
             .assetUtxos(asset, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -122,7 +122,7 @@ export class AssetsApi extends BaseAPI {
     public policyAccounts(policy: string, queryParams?: PolicyAccountsQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
             .policyAccounts(policy, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -137,7 +137,7 @@ export class AssetsApi extends BaseAPI {
     public policyAddresses(policy: string, queryParams?: PolicyAddressesQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
             .policyAddresses(policy, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -152,7 +152,7 @@ export class AssetsApi extends BaseAPI {
     public policyInfo(policy: string, queryParams?: PolicyInfoQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
             .policyInfo(policy, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -167,7 +167,7 @@ export class AssetsApi extends BaseAPI {
     public policyTxs(policy: string, queryParams?: PolicyTxsQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
             .policyTxs(policy, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -182,7 +182,7 @@ export class AssetsApi extends BaseAPI {
     public policyUtxos(policy: string, queryParams?: PolicyUtxosQueryParams, options?: AxiosRequestConfig) {
         return AssetsApiFp(this.configuration)
             .policyUtxos(policy, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 }
 

--- a/src/api/blocks/helpers.ts
+++ b/src/api/blocks/helpers.ts
@@ -1,4 +1,4 @@
-import globalAxios, { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
+import { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
 import { RequestArgs } from '../../base';
 import {
     assertParamExists,
@@ -77,7 +77,7 @@ export const BlocksApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedBlockInfo>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.blockInfo(hashOrHeight, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
     };
 };

--- a/src/api/blocks/index.ts
+++ b/src/api/blocks/index.ts
@@ -20,6 +20,6 @@ export class BlocksApi extends BaseAPI {
     public blockInfo(hashOrHeight: string, options?: AxiosRequestConfig) {
         return BlocksApiFp(this.configuration)
             .blockInfo(hashOrHeight, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 }

--- a/src/api/datum/helpers.ts
+++ b/src/api/datum/helpers.ts
@@ -1,4 +1,4 @@
-import globalAxios, { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
+import { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
 import { RequestArgs } from '../../base';
 import {
     assertParamExists,
@@ -77,7 +77,7 @@ export const DatumApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedDatum>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.lookupDatum(datumHash, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
     };
 };

--- a/src/api/datum/index.ts
+++ b/src/api/datum/index.ts
@@ -20,6 +20,6 @@ export class DatumApi extends BaseAPI {
     public lookupDatum(datumHash: string, options?: AxiosRequestConfig) {
         return DatumApiFp(this.configuration)
             .lookupDatum(datumHash, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 }

--- a/src/api/ecosystem/helpers.ts
+++ b/src/api/ecosystem/helpers.ts
@@ -1,4 +1,4 @@
-import globalAxios, { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
+import { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
 import { RequestArgs } from '../../base';
 import {
     assertParamExists,
@@ -77,7 +77,7 @@ export const EcosystemApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedAddress>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.adahandleResolve(handle, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
     };
 };

--- a/src/api/ecosystem/index.ts
+++ b/src/api/ecosystem/index.ts
@@ -20,6 +20,6 @@ export class EcosystemApi extends BaseAPI {
     public adahandleResolve(handle: string, options?: AxiosRequestConfig) {
         return EcosystemApiFp(this.configuration)
             .adahandleResolve(handle, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 }

--- a/src/api/epochs/helpers.ts
+++ b/src/api/epochs/helpers.ts
@@ -1,4 +1,4 @@
-import globalAxios, { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
+import { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
 import { RequestArgs } from '../../base';
 import {
     DUMMY_BASE_URL,
@@ -107,7 +107,7 @@ export const EpochsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedCurrentEpochInfo>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.currentEpoch(options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns a summary of information about a specific epoch
@@ -121,7 +121,7 @@ export const EpochsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedEpochInfo>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.epochInfo(epochNo, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
     };
 };

--- a/src/api/epochs/index.ts
+++ b/src/api/epochs/index.ts
@@ -19,7 +19,7 @@ export class EpochsApi extends BaseAPI {
     public currentEpoch(options?: AxiosRequestConfig) {
         return EpochsApiFp(this.configuration)
             .currentEpoch(options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -33,6 +33,6 @@ export class EpochsApi extends BaseAPI {
     public epochInfo(epochNo: number, options?: AxiosRequestConfig) {
         return EpochsApiFp(this.configuration)
             .epochInfo(epochNo, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 }

--- a/src/api/general/helpers.ts
+++ b/src/api/general/helpers.ts
@@ -1,4 +1,4 @@
-import globalAxios, { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
+import { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
 import { RequestArgs } from '../../base';
 import { DUMMY_BASE_URL, setApiKeyToObject, setSearchParams, toPathString, createRequestFunction } from '../../common';
 import { Configuration } from '../../configuration';
@@ -163,7 +163,7 @@ export const GeneralApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedChainTip>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.chainTip(options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns the blockchain era history
@@ -175,7 +175,7 @@ export const GeneralApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedEraSummaries>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.eraHistory(options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns the current blockchain protocol parameters
@@ -187,7 +187,7 @@ export const GeneralApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedProtocolParameters>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.protocolParams(options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns the blockchain system start time
@@ -199,7 +199,7 @@ export const GeneralApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedSystemStart>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.systemStart(options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
     };
 };

--- a/src/api/general/index.ts
+++ b/src/api/general/index.ts
@@ -19,7 +19,7 @@ export class GeneralApi extends BaseAPI {
     public chainTip(options?: AxiosRequestConfig) {
         return GeneralApiFp(this.configuration)
             .chainTip(options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -32,7 +32,7 @@ export class GeneralApi extends BaseAPI {
     public eraHistory(options?: AxiosRequestConfig) {
         return GeneralApiFp(this.configuration)
             .eraHistory(options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -45,7 +45,7 @@ export class GeneralApi extends BaseAPI {
     public protocolParams(options?: AxiosRequestConfig) {
         return GeneralApiFp(this.configuration)
             .protocolParams(options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -58,6 +58,6 @@ export class GeneralApi extends BaseAPI {
     public systemStart(options?: AxiosRequestConfig) {
         return GeneralApiFp(this.configuration)
             .systemStart(options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 }

--- a/src/api/pools/helpers.ts
+++ b/src/api/pools/helpers.ts
@@ -1,4 +1,4 @@
-import globalAxios, { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
+import { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
 import { RequestArgs } from '../../base';
 import {
     DUMMY_BASE_URL,
@@ -359,7 +359,7 @@ export const PoolsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedPoolListInfo>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.listPools(queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Return information about blocks minted by a given pool for all epochs (or just for epoch `epoch_no` if provided)
@@ -375,7 +375,7 @@ export const PoolsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedPoolBlock>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.poolBlocks(poolId, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns a list of delegators of the specified pool
@@ -391,7 +391,7 @@ export const PoolsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedDelegatorInfo>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.poolDelegators(poolId, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns per-epoch information about the specified pool (or just for epoch `epoch_no` if provided)
@@ -407,7 +407,7 @@ export const PoolsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedPoolHistory>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.poolHistory(poolId, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns current information about the specified pool
@@ -421,7 +421,7 @@ export const PoolsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedPoolInfo>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.poolInfo(poolId, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns the metadata declared on-chain by the specified stake pool
@@ -435,7 +435,7 @@ export const PoolsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedPoolMetadata>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.poolMetadata(poolId, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns a list of relays declared on-chain by the specified stake pool
@@ -449,7 +449,7 @@ export const PoolsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedPoolRelays>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.poolRelays(poolId, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns a list of updates relating to the specified pool
@@ -463,7 +463,7 @@ export const PoolsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedPoolUpdates>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.poolUpdates(poolId, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
     };
 };

--- a/src/api/pools/index.ts
+++ b/src/api/pools/index.ts
@@ -21,7 +21,7 @@ export class PoolsApi extends BaseAPI {
     public listPools(queryParams?: ListPoolsQueryParams, options?: AxiosRequestConfig) {
         return PoolsApiFp(this.configuration)
             .listPools(queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -36,7 +36,7 @@ export class PoolsApi extends BaseAPI {
     public poolBlocks(poolId: string, queryParams?: PoolBlocksQueryParams, options?: AxiosRequestConfig) {
         return PoolsApiFp(this.configuration)
             .poolBlocks(poolId, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -51,7 +51,7 @@ export class PoolsApi extends BaseAPI {
     public poolDelegators(poolId: string, queryParams?: PoolDelegatorsQueryParams, options?: AxiosRequestConfig) {
         return PoolsApiFp(this.configuration)
             .poolDelegators(poolId, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -66,7 +66,7 @@ export class PoolsApi extends BaseAPI {
     public poolHistory(poolId: string, queryParams?: PoolHistoryQueryParams, options?: AxiosRequestConfig) {
         return PoolsApiFp(this.configuration)
             .poolHistory(poolId, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -80,7 +80,7 @@ export class PoolsApi extends BaseAPI {
     public poolInfo(poolId: string, options?: AxiosRequestConfig) {
         return PoolsApiFp(this.configuration)
             .poolInfo(poolId, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -94,7 +94,7 @@ export class PoolsApi extends BaseAPI {
     public poolMetadata(poolId: string, options?: AxiosRequestConfig) {
         return PoolsApiFp(this.configuration)
             .poolMetadata(poolId, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -108,7 +108,7 @@ export class PoolsApi extends BaseAPI {
     public poolRelays(poolId: string, options?: AxiosRequestConfig) {
         return PoolsApiFp(this.configuration)
             .poolRelays(poolId, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -122,7 +122,7 @@ export class PoolsApi extends BaseAPI {
     public poolUpdates(poolId: string, options?: AxiosRequestConfig) {
         return PoolsApiFp(this.configuration)
             .poolUpdates(poolId, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 }
 

--- a/src/api/scripts/helpers.ts
+++ b/src/api/scripts/helpers.ts
@@ -1,4 +1,4 @@
-import globalAxios, { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
+import { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
 import { RequestArgs } from '../../base';
 import {
     assertParamExists,
@@ -77,7 +77,7 @@ export const ScriptsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedScript>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.scriptByHash(scriptHash, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
     };
 };

--- a/src/api/scripts/index.ts
+++ b/src/api/scripts/index.ts
@@ -20,6 +20,6 @@ export class ScriptsApi extends BaseAPI {
     public scriptByHash(scriptHash: string, options?: AxiosRequestConfig) {
         return ScriptsApiFp(this.configuration)
             .scriptByHash(scriptHash, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 }

--- a/src/api/transactionManager/helpers.ts
+++ b/src/api/transactionManager/helpers.ts
@@ -1,4 +1,4 @@
-import globalAxios, { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
+import { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
 import { RequestArgs } from '../../base';
 import {
     DUMMY_BASE_URL,
@@ -190,7 +190,7 @@ export const TransactionManagerApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<TxManagerState>>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.txManagerHistory(queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns the most recent state of a transaction
@@ -204,7 +204,7 @@ export const TransactionManagerApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TxManagerState>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.txManagerState(txHash, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Submit a signed and serialized transaction to the network. A transaction submited with this endpoint will be [monitored by Maestro](../Dapp%20Platform/Transaction%20Manager).
@@ -218,7 +218,7 @@ export const TransactionManagerApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.txManagerSubmit(body, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Submit a signed and serialized transaction to the network. A transaction submited with this endpoint will be [Turbo Submitted and Monitored by Maestro](../Dapp%20Platform/Turbo%20Transaction).
@@ -232,7 +232,7 @@ export const TransactionManagerApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.txManagerTurboSubmit(body, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
     };
 };

--- a/src/api/transactionManager/index.ts
+++ b/src/api/transactionManager/index.ts
@@ -21,7 +21,7 @@ export class TransactionManagerApi extends BaseAPI {
     public txManagerHistory(queryParams?: TxManagerHistoryQueryParams, options?: AxiosRequestConfig) {
         return TransactionManagerApiFp(this.configuration)
             .txManagerHistory(queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -35,7 +35,7 @@ export class TransactionManagerApi extends BaseAPI {
     public txManagerState(txHash: string, options?: AxiosRequestConfig) {
         return TransactionManagerApiFp(this.configuration)
             .txManagerState(txHash, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -49,7 +49,7 @@ export class TransactionManagerApi extends BaseAPI {
     public txManagerSubmit(body: string | Uint8Array, options?: AxiosRequestConfig) {
         return TransactionManagerApiFp(this.configuration)
             .txManagerSubmit(body, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -63,6 +63,6 @@ export class TransactionManagerApi extends BaseAPI {
     public txManagerTurboSubmit(body: string | Uint8Array, options?: AxiosRequestConfig) {
         return TransactionManagerApiFp(this.configuration)
             .txManagerTurboSubmit(body, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 }

--- a/src/api/transactions/helpers.ts
+++ b/src/api/transactions/helpers.ts
@@ -1,4 +1,4 @@
-import globalAxios, { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
+import { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
 import { RequestArgs } from '../../base';
 import {
     assertParamExists,
@@ -252,7 +252,7 @@ export const TransactionsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedAddress>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.addressByTxo(txHash, index, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns hex-encoded CBOR bytes of a transaction
@@ -266,7 +266,7 @@ export const TransactionsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedTxCbor>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.txCborByTxHash(txHash, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns detailed information about a transaction
@@ -280,7 +280,7 @@ export const TransactionsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedTransactionInfo>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.txInfo(txHash, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns the specified transaction output.
@@ -298,7 +298,7 @@ export const TransactionsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedUtxo>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.txoByTxoRef(txHash, index, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Returns the specified transaction outputs
@@ -314,7 +314,7 @@ export const TransactionsApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedUtxoWithBytes>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.txosByTxoRefs(requestBody, queryParams, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
     };
 };

--- a/src/api/transactions/index.ts
+++ b/src/api/transactions/index.ts
@@ -22,7 +22,7 @@ export class TransactionsApi extends BaseAPI {
     public addressByTxo(txHash: string, index: number, options?: AxiosRequestConfig) {
         return TransactionsApiFp(this.configuration)
             .addressByTxo(txHash, index, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -36,7 +36,7 @@ export class TransactionsApi extends BaseAPI {
     public txCborByTxHash(txHash: string, options?: AxiosRequestConfig) {
         return TransactionsApiFp(this.configuration)
             .txCborByTxHash(txHash, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -50,7 +50,7 @@ export class TransactionsApi extends BaseAPI {
     public txInfo(txHash: string, options?: AxiosRequestConfig) {
         return TransactionsApiFp(this.configuration)
             .txInfo(txHash, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -71,7 +71,7 @@ export class TransactionsApi extends BaseAPI {
     ) {
         return TransactionsApiFp(this.configuration)
             .txoByTxoRef(txHash, index, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -90,6 +90,6 @@ export class TransactionsApi extends BaseAPI {
     ) {
         return TransactionsApiFp(this.configuration)
             .txosByTxoRefs(requestBody, queryParams, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 }

--- a/src/api/vesting/helpers.ts
+++ b/src/api/vesting/helpers.ts
@@ -1,4 +1,4 @@
-import globalAxios, { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
+import { AxiosRequestConfig, AxiosInstance, AxiosPromise } from 'axios';
 import { RequestArgs } from '../../base';
 import {
     assertParamExists,
@@ -39,7 +39,7 @@ export const VestingApiAxiosParamCreator = function (configuration: Configuratio
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             const { baseOptions } = configuration;
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+            const localVarRequestOptions: AxiosRequestConfig = { method: 'POST', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -169,12 +169,12 @@ export const VestingApiFp = function (configuration: Configuration) {
         async contractsVestingCollectBeneficiaryPost(
             beneficiary: string,
             options?: AxiosRequestConfig,
-        ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ContractsVestingLockPost200Response>> {
+        ): Promise<(basePath?: string) => AxiosPromise<ContractsVestingLockPost200Response>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.contractsVestingCollectBeneficiaryPost(
                 beneficiary,
                 options,
             );
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Lock assets into the vesting contract
@@ -191,7 +191,7 @@ export const VestingApiFp = function (configuration: Configuration) {
                 contractsVestingLockPostRequest,
                 options,
             );
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
         /**
          * Detailed list of vesting assets at a beneficiary address
@@ -208,7 +208,7 @@ export const VestingApiFp = function (configuration: Configuration) {
                 beneficiary,
                 options,
             );
-            return createRequestFunction(localVarAxiosArgs, globalAxios, configuration);
+            return createRequestFunction(localVarAxiosArgs, configuration);
         },
     };
 };

--- a/src/api/vesting/index.ts
+++ b/src/api/vesting/index.ts
@@ -21,7 +21,7 @@ export class VestingApi extends BaseAPI {
     public contractsVestingCollectBeneficiaryPost(beneficiary: string, options?: AxiosRequestConfig) {
         return VestingApiFp(this.configuration)
             .contractsVestingCollectBeneficiaryPost(beneficiary, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -38,7 +38,7 @@ export class VestingApi extends BaseAPI {
     ) {
         return VestingApiFp(this.configuration)
             .contractsVestingLockPost(contractsVestingLockPostRequest, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 
     /**
@@ -52,6 +52,6 @@ export class VestingApi extends BaseAPI {
     public contractsVestingStateBeneficiaryGet(beneficiary: string, options?: AxiosRequestConfig) {
         return VestingApiFp(this.configuration)
             .contractsVestingStateBeneficiaryGet(beneficiary, options)
-            .then((request) => request(this.axios));
+            .then((request) => request());
     }
 }

--- a/src/base.ts
+++ b/src/base.ts
@@ -18,7 +18,7 @@ export interface RequestArgs {
  * @class BaseAPI
  */
 export class BaseAPI {
-    constructor(protected configuration: Configuration, protected axios: AxiosInstance = globalAxios) {}
+    constructor(protected configuration: Configuration) {}
 }
 
 /**

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,4 +1,4 @@
-import type { AxiosInstance, AxiosResponse } from 'axios';
+import type { AxiosResponse } from 'axios';
 import type { Configuration } from './configuration';
 import type { RequestArgs } from './base';
 import { RequiredError } from './base';
@@ -87,13 +87,9 @@ export const toPathString = function (url: URL) {
  *
  * @export
  */
-export const createRequestFunction = function (
-    axiosArgs: RequestArgs,
-    globalAxios: AxiosInstance,
-    configuration: Configuration,
-) {
-    return <T = unknown, R = AxiosResponse<T>>(axios: AxiosInstance = globalAxios) => {
+export const createRequestFunction = function (axiosArgs: RequestArgs, configuration: Configuration) {
+    return <T = unknown, R = AxiosResponse<T>>() => {
         const axiosRequestArgs = { ...axiosArgs.options, url: configuration.baseUrl + axiosArgs.url };
-        return axios.request<T, R>(axiosRequestArgs);
+        return configuration.axiosInstance.request<T, R>(axiosRequestArgs);
     };
 };

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,9 +1,12 @@
+import globalAxios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+
 export type MaestroSupportedNetworks = 'Mainnet' | 'Preprod' | 'Preview';
 
 export interface ConfigurationParameters {
-    apiKey: string;
-    network: MaestroSupportedNetworks;
-    baseOptions?: any;
+    readonly apiKey: string;
+    readonly network: MaestroSupportedNetworks;
+    readonly baseOptions?: AxiosRequestConfig;
+    readonly axiosInstance?: AxiosInstance;
 }
 
 export class Configuration {
@@ -12,7 +15,7 @@ export class Configuration {
      * @param name security name
      * @memberof Configuration
      */
-    apiKey: string;
+    readonly apiKey: string;
 
     /**
      * base url of network request
@@ -20,20 +23,23 @@ export class Configuration {
      * @type {string}
      * @memberof Configuration
      */
-    baseUrl: string;
+    readonly baseUrl: string;
 
     /**
      * base options for axios calls
      *
-     * @type {any}
+     * @type {AxiosRequestConfig}
      * @memberof Configuration
      */
-    baseOptions?: any;
+    readonly baseOptions?: AxiosRequestConfig;
+
+    readonly axiosInstance: AxiosInstance;
 
     constructor(param: ConfigurationParameters) {
         this.apiKey = param.apiKey;
         this.baseUrl = `https://${param.network}.gomaestro-api.org/v1`;
         this.baseOptions = param.baseOptions;
+        this.axiosInstance = param.axiosInstance ?? globalAxios;
     }
 
     /**


### PR DESCRIPTION
## Summary

Feature: User can now give its own axios instance to be used. If none is given, global one is used. This allows additional configurations such as using axios interceptors, etc.

Chore: This also consolidates Configuration as the single source of truth for the axios instance.

## Type of Change

Please mark the relevant option(s) for your pull request:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Checklist

Please ensure that your pull request meets the following criteria:

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My code follows the project's coding style and best practices
- [x] My code is appropriately commented and includes relevant documentation
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests pass
- [x] I have updated the documentation, if necessary


