### PR TITLE
Utxo and PoolInfo amounts to string + axios update + new endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prettier": "^2.8.8"
   },
   "dependencies": {
-    "axios": "^1.5.0"
+    "axios": "^1.6.0"
   },
   "lint-staged": {
     "src/**/*.{js,ts,},": [

--- a/package.json
+++ b/package.json
@@ -23,14 +23,12 @@
   "author": "gomaestro.org",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@changesets/cli": "^2.26.2",
     "@commitlint/cli": "^17.4.3",
     "@commitlint/config-conventional": "^17.4.3",
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "@typescript-eslint/parser": "^5.59.1",
     "commitlint": "^17.4.3",
-    "@changesets/cli": "^2.26.2",
-    "tsup": "^7.2.0",
-    "typescript": "^5.2.2",
     "eslint": "^8.39.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^8.8.0",
@@ -38,10 +36,12 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^4.2.1",
     "husky": "^8.0.3",
-    "prettier": "^2.8.8"
+    "prettier": "^2.8.8",
+    "tsup": "^7.2.0",
+    "typescript": "^5.2.2"
   },
   "dependencies": {
-    "axios": "^1.6.0"
+    "axios": "^1.6.1"
   },
   "lint-staged": {
     "src/**/*.{js,ts,},": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   axios:
-    specifier: ^1.5.0
-    version: 1.5.0
+    specifier: ^1.6.1
+    version: 1.6.1
 
 devDependencies:
   '@changesets/cli':
@@ -1146,10 +1146,10 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /axios@1.5.0:
-    resolution: {integrity: sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==}
+  /axios@1.6.1:
+    resolution: {integrity: sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.3
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -2058,8 +2058,8 @@ packages:
     resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
     dev: true
 
-  /follow-redirects@1.15.2:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+  /follow-redirects@1.15.3:
+    resolution: {integrity: sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'

--- a/src/api/accounts/helpers.ts
+++ b/src/api/accounts/helpers.ts
@@ -7,6 +7,7 @@ import {
     setSearchParams,
     toPathString,
     createRequestFunction,
+    HEADER_AMOUNTS_AS_STRING,
 } from '../../common';
 import { Configuration } from '../../configuration';
 import {
@@ -108,7 +109,7 @@ export const AccountsApiAxiosParamCreator = function (configuration: Configurati
                 ...localVarHeaderParameter,
                 ...headersFromBaseOptions,
                 ...options.headers,
-                'amounts-as-string': 'true', // temporary header until this becomes default behaviour
+                ...HEADER_AMOUNTS_AS_STRING,
             };
 
             return {

--- a/src/api/accounts/helpers.ts
+++ b/src/api/accounts/helpers.ts
@@ -108,6 +108,7 @@ export const AccountsApiAxiosParamCreator = function (configuration: Configurati
                 ...localVarHeaderParameter,
                 ...headersFromBaseOptions,
                 ...options.headers,
+                'amounts-as-string': 'true', // temporary header until this becomes default behaviour
             };
 
             return {

--- a/src/api/addresses/helpers.ts
+++ b/src/api/addresses/helpers.ts
@@ -270,6 +270,7 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
                 ...localVarHeaderParameter,
                 ...headersFromBaseOptions,
                 ...options.headers,
+                'amounts-as-string': 'true', // temporary header until this becomes default behaviour
             };
 
             return {
@@ -311,6 +312,7 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
                 ...localVarHeaderParameter,
                 ...headersFromBaseOptions,
                 ...options.headers,
+                'amounts-as-string': 'true', // temporary header until this becomes default behaviour
             };
             localVarRequestOptions.data = serializeDataIfNeeded(requestBody, localVarRequestOptions, configuration);
 
@@ -354,6 +356,7 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
                 ...localVarHeaderParameter,
                 ...headersFromBaseOptions,
                 ...options.headers,
+                'amounts-as-string': 'true', // temporary header until this becomes default behaviour
             };
 
             return {

--- a/src/api/addresses/helpers.ts
+++ b/src/api/addresses/helpers.ts
@@ -365,6 +365,49 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * Return detailed information on UTxOs which are controlled by some payment credentials in the specified list of payment credentials
+         * @summary UTxOs at multiple payment credentials
+         * @param {Array<string>} requestBody
+         * @param {UtxosByAddressesQueryParams} [localVarQueryParameter] Query parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        utxosByPaymentCreds: async (
+            requestBody: Array<string>,
+            localVarQueryParameter: UtxosByAddressesQueryParams = {},
+            options: AxiosRequestConfig = {},
+        ): Promise<RequestArgs> => {
+            // verify required parameter 'requestBody' is not null or undefined
+            assertParamExists('utxosByPaymentCreds', 'requestBody', requestBody);
+            const localVarPath = `/addresses/cred/utxos`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            const { baseOptions } = configuration;
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+
+            // authentication api-key required
+            setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {
+                ...localVarHeaderParameter,
+                ...headersFromBaseOptions,
+                ...options.headers,
+                ...HEADER_AMOUNTS_AS_STRING,
+            };
+            localVarRequestOptions.data = serializeDataIfNeeded(requestBody, localVarRequestOptions, configuration);
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
     };
 };
 
@@ -506,6 +549,26 @@ export const AddressesApiFp = function (configuration: Configuration) {
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedUtxoWithSlot>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.utxosByPaymentCred(
                 credential,
+                queryParams,
+                options,
+            );
+            return createRequestFunction(localVarAxiosArgs, configuration);
+        },
+        /**
+         * Return detailed information on UTxOs which are controlled by some payment credentials in the specified list of payment credentials
+         * @summary UTxOs at multiple payment credentials
+         * @param {Array<string>} requestBody
+         * @param {UtxosByAddressesQueryParams} [queryParams] Query parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async utxosByPaymentCreds(
+            requestBody: Array<string>,
+            queryParams?: UtxosByAddressesQueryParams,
+            options?: AxiosRequestConfig,
+        ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PaginatedUtxoWithSlot>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.utxosByPaymentCreds(
+                requestBody,
                 queryParams,
                 options,
             );

--- a/src/api/addresses/helpers.ts
+++ b/src/api/addresses/helpers.ts
@@ -8,6 +8,7 @@ import {
     toPathString,
     serializeDataIfNeeded,
     createRequestFunction,
+    HEADER_AMOUNTS_AS_STRING,
 } from '../../common';
 import { Configuration } from '../../configuration';
 import {
@@ -270,7 +271,7 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
                 ...localVarHeaderParameter,
                 ...headersFromBaseOptions,
                 ...options.headers,
-                'amounts-as-string': 'true', // temporary header until this becomes default behaviour
+                ...HEADER_AMOUNTS_AS_STRING,
             };
 
             return {
@@ -312,7 +313,7 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
                 ...localVarHeaderParameter,
                 ...headersFromBaseOptions,
                 ...options.headers,
-                'amounts-as-string': 'true', // temporary header until this becomes default behaviour
+                ...HEADER_AMOUNTS_AS_STRING,
             };
             localVarRequestOptions.data = serializeDataIfNeeded(requestBody, localVarRequestOptions, configuration);
 
@@ -356,7 +357,7 @@ export const AddressesApiAxiosParamCreator = function (configuration: Configurat
                 ...localVarHeaderParameter,
                 ...headersFromBaseOptions,
                 ...options.headers,
-                'amounts-as-string': 'true', // temporary header until this becomes default behaviour
+                ...HEADER_AMOUNTS_AS_STRING,
             };
 
             return {

--- a/src/api/addresses/index.ts
+++ b/src/api/addresses/index.ts
@@ -145,6 +145,25 @@ export class AddressesApi extends BaseAPI {
             .utxosByPaymentCred(credential, queryParams, options)
             .then((request) => request());
     }
+
+    /**
+     * Return detailed information on UTxOs which are controlled by some payment creds in the specified list of payment creds
+     * @summary UTxOs at multiple payment creds
+     * @param {Array<string>} requestBody
+     * @param {UtxosByAddressesQueryParams} [queryParams] Query parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AddressesApi
+     */
+    public utxosByPaymentCreds(
+        requestBody: Array<string>,
+        queryParams?: UtxosByAddressesQueryParams,
+        options?: AxiosRequestConfig,
+    ) {
+        return AddressesApiFp(this.configuration)
+            .utxosByPaymentCreds(requestBody, queryParams, options)
+            .then((request) => request());
+    }
 }
 
 export * from './type';

--- a/src/api/pools/helpers.ts
+++ b/src/api/pools/helpers.ts
@@ -216,6 +216,7 @@ export const PoolsApiAxiosParamCreator = function (configuration: Configuration)
                 ...localVarHeaderParameter,
                 ...headersFromBaseOptions,
                 ...options.headers,
+                'amounts-as-string': 'true', // temporary header until this becomes default behaviour
             };
 
             return {

--- a/src/api/pools/helpers.ts
+++ b/src/api/pools/helpers.ts
@@ -7,6 +7,7 @@ import {
     toPathString,
     assertParamExists,
     createRequestFunction,
+    HEADER_AMOUNTS_AS_STRING,
 } from '../../common';
 import { Configuration } from '../../configuration';
 import {
@@ -216,7 +217,7 @@ export const PoolsApiAxiosParamCreator = function (configuration: Configuration)
                 ...localVarHeaderParameter,
                 ...headersFromBaseOptions,
                 ...options.headers,
-                'amounts-as-string': 'true', // temporary header until this becomes default behaviour
+                ...HEADER_AMOUNTS_AS_STRING,
             };
 
             return {

--- a/src/api/transactions/helpers.ts
+++ b/src/api/transactions/helpers.ts
@@ -220,6 +220,7 @@ export const TransactionsApiAxiosParamCreator = function (configuration: Configu
                 ...localVarHeaderParameter,
                 ...headersFromBaseOptions,
                 ...options.headers,
+                'amounts-as-string': 'true', // temporary header until this becomes default behaviour
             };
             localVarRequestOptions.data = serializeDataIfNeeded(requestBody, localVarRequestOptions, configuration);
 

--- a/src/api/transactions/helpers.ts
+++ b/src/api/transactions/helpers.ts
@@ -8,6 +8,7 @@ import {
     toPathString,
     serializeDataIfNeeded,
     createRequestFunction,
+    HEADER_AMOUNTS_AS_STRING,
 } from '../../common';
 import { Configuration } from '../../configuration';
 import {
@@ -220,7 +221,7 @@ export const TransactionsApiAxiosParamCreator = function (configuration: Configu
                 ...localVarHeaderParameter,
                 ...headersFromBaseOptions,
                 ...options.headers,
-                'amounts-as-string': 'true', // temporary header until this becomes default behaviour
+                ...HEADER_AMOUNTS_AS_STRING,
             };
             localVarRequestOptions.data = serializeDataIfNeeded(requestBody, localVarRequestOptions, configuration);
 

--- a/src/api/type.ts
+++ b/src/api/type.ts
@@ -271,7 +271,7 @@ export interface AddressTransaction {
 export interface Asset {
     /**
      * Amount of the asset
-     * @type {number}
+     * @type {string}
      * @memberof Asset
      */
     amount: string;
@@ -2237,10 +2237,10 @@ export interface PoolInfo {
     active_epoch_no: number;
     /**
      * Active stake
-     * @type {number}
+     * @type {string}
      * @memberof PoolInfo
      */
-    active_stake?: number | null;
+    active_stake?: string | null;
     /**
      * Number of blocks created
      * @type {number}
@@ -2249,10 +2249,10 @@ export interface PoolInfo {
     block_count?: number | null;
     /**
      * Pool fixed cost
-     * @type {number}
+     * @type {string}
      * @memberof PoolInfo
      */
-    fixed_cost: number;
+    fixed_cost: string;
     /**
      * Number of current delegators
      * @type {number}
@@ -2261,10 +2261,10 @@ export interface PoolInfo {
     live_delegators: number;
     /**
      * Account balance of pool owners
-     * @type {number}
+     * @type {string}
      * @memberof PoolInfo
      */
-    live_pledge?: number | null;
+    live_pledge?: string | null;
     /**
      * Live saturation
      * @type {string}
@@ -2273,16 +2273,16 @@ export interface PoolInfo {
     live_saturation?: string | null;
     /**
      * Live stake
-     * @type {number}
+     * @type {string}
      * @memberof PoolInfo
      */
-    live_stake?: number | null;
+    live_stake?: string | null;
     /**
      * Pool margin
-     * @type {number}
+     * @type {string}
      * @memberof PoolInfo
      */
-    margin: number;
+    margin: string;
     /**
      * Hash of the pool metadata
      * @type {string}
@@ -2321,10 +2321,10 @@ export interface PoolInfo {
     owners: Array<string>;
     /**
      * Pool pledge
-     * @type {number}
+     * @type {string}
      * @memberof PoolInfo
      */
-    pledge: number;
+    pledge: string;
     /**
      * Bech32 encoded pool ID
      * @type {string}

--- a/src/api/type.ts
+++ b/src/api/type.ts
@@ -274,7 +274,7 @@ export interface Asset {
      * @type {number}
      * @memberof Asset
      */
-    amount: number;
+    amount: string;
     /**
      * Asset (either `lovelace` or concatenation of hex encoded policy ID and asset name for native asset)
      * @type {string}

--- a/src/common.ts
+++ b/src/common.ts
@@ -10,6 +10,15 @@ import { RequiredError } from './base';
 export const DUMMY_BASE_URL = 'https://example.com';
 
 /**
+ * temporary header used by some endpoints to indicate that the amounts
+ * should be returned as strings instead of numbers
+ * @export
+ */
+export const HEADER_AMOUNTS_AS_STRING = {
+    'amounts-as-string': 'true',
+};
+
+/**
  *
  * @throws {RequiredError}
  * @export

--- a/yarn.lock
+++ b/yarn.lock
@@ -979,10 +979,10 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-axios@^1.5.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.5.1.tgz#11fbaa11fc35f431193a9564109c88c1f27b585f"
-  integrity sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==
+axios@^1.6.0:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.1.tgz#76550d644bf0a2d469a01f9244db6753208397d7"
+  integrity sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==
   dependencies:
     follow-redirects "^1.15.0"
     form-data "^4.0.0"


### PR DESCRIPTION
Hey, the changes are:
* updated the interfaces and following APIs to return the amounts as string:
* added `addresses/cred/utxos` endpoint
* Updated axios to ^1.6.0 to mitigate vulnerability in ^1.5.0 (reported in `yarn audit`)

The updated APIs are:

GET  /accounts/{stake_addr}/assets

GET  /addresses/{address}/utxos
POST /addresses/utxos
GET  /addresses/cred/{credential}/utxos
POST /addresses/cred/utxos (NEW ENDPOINT)

GET  /pools/{pool_id}/info

POST /transactions/outputs
