### PR TITLE
Alex/datum

### DIFF
--- a/src/api/datum/helpers.ts
+++ b/src/api/datum/helpers.ts
@@ -78,6 +78,8 @@ export const DatumApiAxiosParamCreator = function (configuration: Configuration)
             // authentication api-key required
             setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
 
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {

--- a/src/api/datum/helpers.ts
+++ b/src/api/datum/helpers.ts
@@ -9,7 +9,7 @@ import {
     createRequestFunction,
 } from '../../common';
 import { Configuration } from '../../configuration';
-import { TimestampedDatum } from '../type';
+import { TimestampedDatum, TimestampedDatums } from '../type';
 
 /**
  * DatumApi - axios parameter creator
@@ -27,7 +27,7 @@ export const DatumApiAxiosParamCreator = function (configuration: Configuration)
         lookupDatum: async (datumHash: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'datumHash' is not null or undefined
             assertParamExists('lookupDatum', 'datumHash', datumHash);
-            const localVarPath = `/datum/{datum_hash}`.replace(
+            const localVarPath = `/datums/{datum_hash}`.replace(
                 `{${'datum_hash'}}`,
                 encodeURIComponent(String(datumHash)),
             );
@@ -36,6 +36,41 @@ export const DatumApiAxiosParamCreator = function (configuration: Configuration)
             const { baseOptions } = configuration;
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication api-key required
+            setApiKeyToObject(localVarHeaderParameter, 'api-key', configuration);
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {
+                ...localVarHeaderParameter,
+                ...headersFromBaseOptions,
+                ...options.headers,
+            };
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Returns the datums corresponding to the specified datum hashes, for the datums which have been seen on-chain
+         * @summary Datums by datum hashes
+         * @param {Array<string>} requestBody Array of hex encoded datum hashes
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        lookupDatums: async (requestBody: Array<string>, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'requestBody' is not null or undefined
+            assertParamExists('lookupDatums', 'requestBody', requestBody);
+            const localVarPath = `/datums`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            const { baseOptions } = configuration;
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -77,6 +112,20 @@ export const DatumApiFp = function (configuration: Configuration) {
             options?: AxiosRequestConfig,
         ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedDatum>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.lookupDatum(datumHash, options);
+            return createRequestFunction(localVarAxiosArgs, configuration);
+        },
+        /**
+         * Returns the datums corresponding to the specified datum hashes, for the datums which have been seen on-chain
+         * @summary Datums by datum hashes
+         * @param {Array<string>} requestBody Array of hex encoded datum hashes
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async lookupDatums(
+            requestBody: Array<string>,
+            options?: AxiosRequestConfig,
+        ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimestampedDatums>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.lookupDatums(requestBody, options);
             return createRequestFunction(localVarAxiosArgs, configuration);
         },
     };

--- a/src/api/datum/helpers.ts
+++ b/src/api/datum/helpers.ts
@@ -7,6 +7,7 @@ import {
     setSearchParams,
     toPathString,
     createRequestFunction,
+    serializeDataIfNeeded,
 } from '../../common';
 import { Configuration } from '../../configuration';
 import { TimestampedDatum, TimestampedDatums } from '../type';
@@ -84,6 +85,7 @@ export const DatumApiAxiosParamCreator = function (configuration: Configuration)
                 ...headersFromBaseOptions,
                 ...options.headers,
             };
+            localVarRequestOptions.data = serializeDataIfNeeded(requestBody, localVarRequestOptions, configuration);
 
             return {
                 url: toPathString(localVarUrlObj),

--- a/src/api/datum/index.ts
+++ b/src/api/datum/index.ts
@@ -17,9 +17,21 @@ export class DatumApi extends BaseAPI {
      * @throws {RequiredError}
      * @memberof DatumApi
      */
-    public lookupDatum(datumHash: string, options?: AxiosRequestConfig) {
-        return DatumApiFp(this.configuration)
-            .lookupDatum(datumHash, options)
-            .then((request) => request());
+    public async lookupDatum(datumHash: string, options?: AxiosRequestConfig) {
+        const request = await DatumApiFp(this.configuration).lookupDatum(datumHash, options);
+        return request();
+    }
+
+    /**
+     * Returns the datums corresponding to the specified datum hashes, for the datums which have been seen on-chain
+     * @summary Datums by datum hashes
+     * @param {Array<string>} requestBody Array of hex encoded datum hashes
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DatumApi
+     */
+    public async lookupDatums(requestBody: Array<string>, options?: AxiosRequestConfig) {
+        const request = await DatumApiFp(this.configuration).lookupDatums(requestBody, options);
+        return request();
     }
 }

--- a/src/api/epochs/helpers.ts
+++ b/src/api/epochs/helpers.ts
@@ -59,10 +59,7 @@ export const EpochsApiAxiosParamCreator = function (configuration: Configuration
         epochInfo: async (epochNo: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'epochNo' is not null or undefined
             assertParamExists('epochInfo', 'epochNo', epochNo);
-            const localVarPath = `/epochs/{epoch_no}/info`.replace(
-                `{${'epoch_no'}}`,
-                encodeURIComponent(String(epochNo)),
-            );
+            const localVarPath = `/epochs/{epoch_no}`.replace(`{${'epoch_no'}}`, encodeURIComponent(String(epochNo)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             const { baseOptions } = configuration;

--- a/src/api/type.ts
+++ b/src/api/type.ts
@@ -1029,6 +1029,18 @@ export interface DelegatorInfo {
  */
 export interface EpochInfo {
     /**
+     * Total active stake in the epoch
+     * @type {number}
+     * @memberof EpochInfo
+     */
+    active_stake?: string | null;
+    /**
+     * Average reward in the epoch
+     * @type {number}
+     * @memberof EpochInfo
+     */
+    average_reward?: string | null;
+    /**
      * Total blocks in the epoch
      * @type {number}
      * @memberof EpochInfo

--- a/src/api/type.ts
+++ b/src/api/type.ts
@@ -3216,6 +3216,25 @@ export interface TimestampedDatum {
 /**
  * Timestamped response. Returns the endpoint response data along with the chain-tip of the indexer, which details at which point in the chain\'s history the data was correct as-of.
  * @export
+ * @interface TimestampedDatums
+ */
+export interface TimestampedDatums {
+    /**
+     * Record of Datum by datum hash
+     * @type {Record<string, Datum | undefined>}
+     * @memberof TimestampedDatum
+     */
+    data: Record<string, Datum | undefined>;
+    /**
+     *
+     * @type {LastUpdated}
+     * @memberof TimestampedDatum
+     */
+    last_updated: LastUpdated;
+}
+/**
+ * Timestamped response. Returns the endpoint response data along with the chain-tip of the indexer, which details at which point in the chain\'s history the data was correct as-of.
+ * @export
  * @interface TimestampedEpochInfo
  */
 export interface TimestampedEpochInfo {

--- a/src/common.ts
+++ b/src/common.ts
@@ -15,7 +15,7 @@ export const DUMMY_BASE_URL = 'https://example.com';
  * @export
  */
 export const HEADER_AMOUNTS_AS_STRING = {
-    'amounts-as-string': 'true',
+    'amounts-as-strings': 'true',
 };
 
 /**


### PR DESCRIPTION
* Fixed the amounts-as-strings header which had a typo and was not applied 💀 
* Changed the url for lookupDatum (was pointing to the deprecated one)
* Added lookupDatums taking an array of datum hashes
* Updated url for specific epoch API call + updated response interface to include new fields