### PR TITLE
Policy Info endpoint URL fixed

### DIFF
--- a/src/api/assets/helpers.ts
+++ b/src/api/assets/helpers.ts
@@ -368,7 +368,7 @@ export const AssetsApiAxiosParamCreator = (configuration: Configuration) => ({
     ): RequestArgs => {
         // verify required parameter 'policy' is not null or undefined
         assertParamExists('policyInfo', 'policy', policy);
-        const localVarPath = `/assets/policy/{policy}`.replace(`{${'policy'}}`, encodeURIComponent(String(policy)));
+        const localVarPath = `/policy/{policy}`.replace(`{${'policy'}}`, encodeURIComponent(String(policy)));
         // use dummy base URL string because the URL constructor only accepts absolute URLs.
         const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
         const { baseOptions } = configuration;

--- a/src/api/assets/helpers.ts
+++ b/src/api/assets/helpers.ts
@@ -368,7 +368,7 @@ export const AssetsApiAxiosParamCreator = (configuration: Configuration) => ({
     ): RequestArgs => {
         // verify required parameter 'policy' is not null or undefined
         assertParamExists('policyInfo', 'policy', policy);
-        const localVarPath = `/policy/{policy}`.replace(`{${'policy'}}`, encodeURIComponent(String(policy)));
+        const localVarPath = `/policy/{policy}/assets`.replace(`{${'policy'}}`, encodeURIComponent(String(policy)));
         // use dummy base URL string because the URL constructor only accepts absolute URLs.
         const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
         const { baseOptions } = configuration;
@@ -407,7 +407,7 @@ export const AssetsApiAxiosParamCreator = (configuration: Configuration) => ({
     ): RequestArgs => {
         // verify required parameter 'policy' is not null or undefined
         assertParamExists('policyTxs', 'policy', policy);
-        const localVarPath = `/assets/policy/{policy}/txs`.replace(`{${'policy'}}`, encodeURIComponent(String(policy)));
+        const localVarPath = `/policy/{policy}/txs`.replace(`{${'policy'}}`, encodeURIComponent(String(policy)));
         // use dummy base URL string because the URL constructor only accepts absolute URLs.
         const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
         const { baseOptions } = configuration;
@@ -446,7 +446,7 @@ export const AssetsApiAxiosParamCreator = (configuration: Configuration) => ({
     ): RequestArgs => {
         // verify required parameter 'policy' is not null or undefined
         assertParamExists('policyUtxos', 'policy', policy);
-        const localVarPath = `/assets/policy/{policy}/utxos`.replace(
+        const localVarPath = `/policy/{policy}/utxos`.replace(
             `{${'policy'}}`,
             encodeURIComponent(String(policy)),
         );


### PR DESCRIPTION
## Summary

The URL for Policy Info seems to have been changed with some recent updates to the Maestro API, this change is to bring the SDK into line for this API endpoint

## Type of Change

Please mark the relevant option(s) for your pull request:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Checklist

Please ensure that your pull request meets the following criteria:

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My code follows the project's coding style and best practices
- [x] My code is appropriately commented and includes relevant documentation
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests pass
- [x] I have updated the documentation, if necessary

## Additional Information

Updated the SDK to call the end point as published here: https://docs.gomaestro.org/Indexer-API/Asset%20Policy/policy-assets

