### PR TITLE
fix: update query parameters type for Transaction API's txosByTxoRefs()

### DIFF
--- a/src/api/transactions/index.ts
+++ b/src/api/transactions/index.ts
@@ -1,7 +1,7 @@
 import { AxiosRequestConfig } from 'axios';
 import { BaseAPI } from '../../base';
 import { TransactionsApiFp } from './helpers';
-import { TxoByTxoRefQueryParams } from './type';
+import { TxoByTxoRefQueryParams, TxosByTxoRefsQueryParams } from './type';
 
 /**
  * TransactionsApi - object-oriented interface
@@ -77,7 +77,7 @@ export class TransactionsApi extends BaseAPI {
      */
     public txosByTxoRefs(
         requestBody: Array<string>,
-        queryParams?: TxoByTxoRefQueryParams,
+        queryParams?: TxosByTxoRefsQueryParams,
         options?: AxiosRequestConfig,
     ) {
         return TransactionsApiFp(this.configuration).txosByTxoRefs(requestBody, queryParams, options)();

--- a/src/api/transactions/type.ts
+++ b/src/api/transactions/type.ts
@@ -32,4 +32,22 @@ export interface TxosByTxoRefsQueryParams {
      * @memberof TxosByTxoRefsQueryParams
      */
     with_cbor?: boolean | null;
+    /**
+     * Do not return 404 if any transactions are not found (404 will still be returned if you specify an index higher than the number of outputs in a transaction)
+     * @type {boolean | null}
+     * @memberof TxosByTxoRefsQueryParams
+     */
+    allow_missing?: boolean | null;
+    /**
+     * The max number of results per page
+     * @type {number | null}
+     * @memberof TxosByTxoRefsQueryParams
+     */
+    count?: number | null;
+    /**
+     * Pagination cursor string, use the cursor included in a page of results to fetch the next page
+     * @type {string | null}
+     * @memberof TxosByTxoRefsQueryParams
+     */
+    cursor?: string | null;
 }


### PR DESCRIPTION
## Summary
These changes aim to bring the Transaction API up to date to the specifications: https://docs.gomaestro.org/Cardano/Indexer-API/Transactions/txos-by-txo-refs.

Changes are:

- Change the query parameters type of the `txosByTxoRefs()` method to reference the correct type.
- Update the TxosByTxoRefsQueryParams type to reflect the documentation.

## Type of Change

Please mark the relevant option(s) for your pull request:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Checklist

Please ensure that your pull request meets the following criteria:

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My code follows the project's coding style and best practices
- [x] My code is appropriately commented and includes relevant documentation
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests pass
- [ ] I have updated the documentation, if necessary
